### PR TITLE
feat: Handshake with main

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 CLI utility to launch [n8n task runners](https://docs.n8n.io/PENDING).
 
 ```sh
-./n8n-launcher launch -type javascript
+./n8n-launcher javascript
 2024/11/15 13:53:33 Starting to execute `launch` command...
 2024/11/15 13:53:33 Loaded config file loaded with a single runner config
 2024/11/15 13:53:33 Changed into working directory: /Users/ivov/Development/n8n-launcher/bin

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module n8n-launcher
 
 go 1.23.3
+
+require github.com/gorilla/websocket v1.5.3

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/internal/auth/handshake.go
+++ b/internal/auth/handshake.go
@@ -171,7 +171,7 @@ func Handshake(cfg HandshakeConfig) error {
 				}
 
 				logs.Logger.Printf("-> Sent message `%s` for offer ID `%s`", msg.Type, msg.OfferID)
-				logs.Logger.Println("Waiting for task offer to be accepted...")
+				logs.Logger.Println("Waiting for launcher's task offer to be accepted...")
 
 			case msgBrokerTaskOfferAccept:
 				msg := message{
@@ -188,8 +188,7 @@ func Handshake(cfg HandshakeConfig) error {
 
 				wsConn.Close() // disregard close error, handshake already completed
 
-				logs.Logger.Printf("Disconnected websocket")
-				logs.Logger.Printf("Completed handshake")
+				logs.Logger.Printf("Disconnected: %s", wsURL.String())
 
 				close(handshakeComplete)
 

--- a/internal/auth/handshake.go
+++ b/internal/auth/handshake.go
@@ -1,0 +1,205 @@
+package auth
+
+import (
+	"encoding/hex"
+	"fmt"
+	"n8n-launcher/internal/logs"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+const (
+	msgRunnerInfo             = "runner:info"
+	msgRunnerTaskOffer        = "runner:taskoffer"
+	msgRunnerTaskDeferred     = "runner:taskdeferred"
+	msgBrokerInfoRequest      = "broker:inforequest"
+	msgBrokerRunnerRegistered = "broker:runnerregistered"
+	msgBrokerTaskOfferAccept  = "broker:taskofferaccept"
+)
+
+type message struct {
+	Type     string   `json:"type"`
+	Types    []string `json:"types,omitempty"`    // for runner:info
+	Name     string   `json:"name,omitempty"`     // for runner:info
+	TaskType string   `json:"taskType,omitempty"` // for runner:taskoffer
+	OfferId  string   `json:"offerId,omitempty"`  // for runner:taskoffer
+	ValidFor int      `json:"validFor,omitempty"` // for runner:taskoffer
+	TaskId   string   `json:"taskId,omitempty"`   // for broker:taskofferaccept
+}
+
+type HandshakeConfig struct {
+	TaskType   string
+	N8nUri     string
+	GrantToken string
+}
+
+func validateConfig(cfg HandshakeConfig) error {
+	if cfg.TaskType == "" {
+		return fmt.Errorf("runner type is missing")
+	}
+
+	if cfg.N8nUri == "" {
+		return fmt.Errorf("n8n URI is missing")
+	}
+
+	if cfg.GrantToken == "" {
+		return fmt.Errorf("grant token is missing")
+	}
+
+	return nil
+}
+
+func buildWebsocketURL(n8nUri, runnerID string) (*url.URL, error) {
+	if !strings.HasPrefix(n8nUri, "http://") && !strings.HasPrefix(n8nUri, "https://") {
+		n8nUri = "http://" + n8nUri
+	}
+
+	u, err := url.Parse(n8nUri)
+	if err != nil {
+		return nil, fmt.Errorf("invalid n8n URI: %w", err)
+	}
+
+	if u.RawQuery != "" {
+		return nil, fmt.Errorf("n8n URI must have no query params")
+	}
+
+	u.Scheme = "ws"
+	u.Path = "/runners/_ws"
+
+	q := u.Query()
+	q.Set("id", runnerID)
+	u.RawQuery = q.Encode()
+
+	return u, nil
+}
+
+func connectToWebsocket(wsURL *url.URL, grantToken string) (*websocket.Conn, error) {
+	reqHeader := map[string][]string{
+		"Authorization": {fmt.Sprintf("Bearer %s", grantToken)},
+	}
+
+	dialer := websocket.Dialer{
+		ReadBufferSize:  512,
+		WriteBufferSize: 512,
+	}
+
+	wsConn, _, err := dialer.Dial(wsURL.String(), reqHeader)
+	if err != nil {
+		return nil, fmt.Errorf("websocket connection failed: %w", err)
+	}
+
+	logs.Logger.Printf("Connected to websocket: %s", wsURL.String())
+
+	return wsConn, nil
+}
+
+// @TODO: Improve
+func RandomId() string {
+	timestamp := time.Now().UTC().String()
+	hexEncoded := hex.EncodeToString([]byte(timestamp))
+
+	return hexEncoded[:8]
+}
+
+// Handshake is the flow where the launcher connects via websocket with main,
+// registers with main's task broker, sends a non-expiring task offer to main, and
+// receives the accept for that offer from main. Note that the handshake completes
+// only once this task offer is accepted, which may take time.
+func Handshake(cfg HandshakeConfig) error {
+	if err := validateConfig(cfg); err != nil {
+		return fmt.Errorf("received invalid handshake config: %w", err)
+	}
+
+	runnerID := "launcher-" + RandomId()
+	wsURL, err := buildWebsocketURL(cfg.N8nUri, "launcher-"+RandomId())
+	if err != nil {
+		return fmt.Errorf("failed to build websocket URL: %w", err)
+	}
+
+	wsConn, err := connectToWebsocket(wsURL, cfg.GrantToken)
+	if err != nil {
+		return err
+	}
+	defer wsConn.Close()
+
+	errReceived := make(chan error)
+	handshakeComplete := make(chan struct{})
+
+	go func() {
+		defer close(errReceived)
+
+		for {
+			var msg message
+			err := wsConn.ReadJSON(&msg)
+			if err != nil {
+				if err == websocket.ErrReadLimit {
+					logs.Logger.Fatal("Websocket message too large for buffer - please increase buffer size")
+				}
+				errReceived <- fmt.Errorf("failed to read message: %w", err)
+				return
+			}
+
+			logs.Logger.Printf("<- Received message `%s`", msg.Type)
+
+			switch msg.Type {
+			case msgBrokerInfoRequest:
+				msg := message{
+					Type:  msgRunnerInfo,
+					Types: []string{cfg.TaskType},
+					Name:  "Launcher",
+				}
+				if err := wsConn.WriteJSON(msg); err != nil {
+					errReceived <- fmt.Errorf("failed to send runner info: %w", err)
+					return
+				}
+
+				logs.Logger.Printf("-> Sent message `%s` for runner ID %s", msg.Type, runnerID)
+
+			case msgBrokerRunnerRegistered:
+				msg := message{
+					Type:     msgRunnerTaskOffer,
+					TaskType: cfg.TaskType,
+					OfferId:  "launcher-" + RandomId(),
+					ValidFor: -1, // non-expiring offer
+				}
+
+				if err := wsConn.WriteJSON(msg); err != nil {
+					errReceived <- fmt.Errorf("failed to send task offer: %w", err)
+					return
+				}
+
+				logs.Logger.Printf("-> Sent message `%s` for offer ID %s", msg.Type, msg.OfferId)
+				logs.Logger.Println("Waiting for task offer to be accepted...")
+
+			case msgBrokerTaskOfferAccept:
+				msg := message{
+					Type:   msgRunnerTaskDeferred,
+					TaskId: msg.TaskId,
+				}
+
+				if err := wsConn.WriteJSON(msg); err != nil {
+					errReceived <- fmt.Errorf("failed to defer task: %w", err)
+					return
+				}
+
+				logs.Logger.Printf("-> Sent message `%s` for task ID %s", msg.Type, msg.TaskId)
+
+				logs.Logger.Printf("Completed handshake")
+
+				close(handshakeComplete)
+
+				return
+			}
+		}
+	}()
+
+	select {
+	case err := <-errReceived:
+		return err
+	case <-handshakeComplete:
+		return nil
+	}
+}

--- a/internal/auth/handshake.go
+++ b/internal/auth/handshake.go
@@ -184,7 +184,7 @@ func Handshake(cfg HandshakeConfig) error {
 					return
 				}
 
-				logs.Logger.Printf("-> Sent message `%s` for task ID %s", msg.Type, msg.TaskID)
+				logs.Logger.Printf("-> Sent message `%s` for task ID `%s`", msg.Type, msg.TaskID)
 
 				wsConn.Close() // disregard close error, handshake already completed
 

--- a/internal/auth/handshake.go
+++ b/internal/auth/handshake.go
@@ -32,7 +32,7 @@ type message struct {
 
 type HandshakeConfig struct {
 	TaskType   string
-	N8nUri     string
+	N8nURI     string
 	GrantToken string
 }
 
@@ -41,7 +41,7 @@ func validateConfig(cfg HandshakeConfig) error {
 		return fmt.Errorf("runner type is missing")
 	}
 
-	if cfg.N8nUri == "" {
+	if cfg.N8nURI == "" {
 		return fmt.Errorf("n8n URI is missing")
 	}
 
@@ -52,12 +52,12 @@ func validateConfig(cfg HandshakeConfig) error {
 	return nil
 }
 
-func buildWebsocketURL(n8nUri, runnerID string) (*url.URL, error) {
-	if !strings.HasPrefix(n8nUri, "http://") && !strings.HasPrefix(n8nUri, "https://") {
-		n8nUri = "http://" + n8nUri
+func buildWebsocketURL(n8nURI, runnerID string) (*url.URL, error) {
+	if !strings.HasPrefix(n8nURI, "http://") && !strings.HasPrefix(n8nURI, "https://") {
+		n8nURI = "http://" + n8nURI
 	}
 
-	u, err := url.Parse(n8nUri)
+	u, err := url.Parse(n8nURI)
 	if err != nil {
 		return nil, fmt.Errorf("invalid n8n URI: %w", err)
 	}
@@ -98,7 +98,7 @@ func connectToWebsocket(wsURL *url.URL, grantToken string) (*websocket.Conn, err
 
 func randomID() string {
 	b := make([]byte, 8)
-	rand.Read(b)
+	_, _ = rand.Read(b)
 	return hex.EncodeToString(b)
 }
 
@@ -114,7 +114,7 @@ func Handshake(cfg HandshakeConfig) error {
 	runnerID := randomID()
 	logs.Logger.Printf("Launcher's runner ID: %s", runnerID)
 
-	wsURL, err := buildWebsocketURL(cfg.N8nUri, runnerID)
+	wsURL, err := buildWebsocketURL(cfg.N8nURI, runnerID)
 	if err != nil {
 		return fmt.Errorf("failed to build websocket URL: %w", err)
 	}

--- a/internal/auth/handshake.go
+++ b/internal/auth/handshake.go
@@ -123,7 +123,6 @@ func Handshake(cfg HandshakeConfig) error {
 	if err != nil {
 		return err
 	}
-	defer wsConn.Close()
 
 	errReceived := make(chan error)
 	handshakeComplete := make(chan struct{})
@@ -187,6 +186,9 @@ func Handshake(cfg HandshakeConfig) error {
 
 				logs.Logger.Printf("-> Sent message `%s` for task ID %s", msg.Type, msg.TaskID)
 
+				wsConn.Close() // disregard close error, handshake already completed
+
+				logs.Logger.Printf("Disconnected websocket")
 				logs.Logger.Printf("Completed handshake")
 
 				close(handshakeComplete)

--- a/internal/auth/handshake.go
+++ b/internal/auth/handshake.go
@@ -91,7 +91,7 @@ func connectToWebsocket(wsURL *url.URL, grantToken string) (*websocket.Conn, err
 		return nil, fmt.Errorf("websocket connection failed: %w", err)
 	}
 
-	logs.Logger.Printf("Connected to websocket: %s", wsURL.String())
+	logs.Logger.Printf("Connected: %s", wsURL.String())
 
 	return wsConn, nil
 }
@@ -111,8 +111,10 @@ func Handshake(cfg HandshakeConfig) error {
 		return fmt.Errorf("received invalid handshake config: %w", err)
 	}
 
-	runnerID := "launcher-" + randomID()
-	wsURL, err := buildWebsocketURL(cfg.N8nUri, "launcher-"+randomID())
+	runnerID := randomID()
+	logs.Logger.Printf("Launcher's runner ID: %s", runnerID)
+
+	wsURL, err := buildWebsocketURL(cfg.N8nUri, runnerID)
 	if err != nil {
 		return fmt.Errorf("failed to build websocket URL: %w", err)
 	}
@@ -154,13 +156,13 @@ func Handshake(cfg HandshakeConfig) error {
 					return
 				}
 
-				logs.Logger.Printf("-> Sent message `%s` for runner ID `%s`", msg.Type, runnerID)
+				logs.Logger.Printf("-> Sent message `%s`", msg.Type)
 
 			case msgBrokerRunnerRegistered:
 				msg := message{
 					Type:     msgRunnerTaskOffer,
 					TaskType: cfg.TaskType,
-					OfferID:  "launcher-" + randomID(),
+					OfferID:  randomID(),
 					ValidFor: -1, // non-expiring offer
 				}
 

--- a/internal/commands/launch.go
+++ b/internal/commands/launch.go
@@ -85,7 +85,7 @@ func (l *LaunchCommand) Execute() error {
 
 	handshakeCfg := auth.HandshakeConfig{
 		TaskType:   l.RunnerType,
-		N8nUri:     n8nURI,
+		N8nURI:     n8nURI,
 		GrantToken: launcherGrantToken,
 	}
 

--- a/internal/commands/launch.go
+++ b/internal/commands/launch.go
@@ -104,7 +104,7 @@ func (l *LaunchCommand) Execute() error {
 
 	// 7. launch runner
 
-	logs.Logger.Println("Launching task runner...")
+	logs.Logger.Println("Task ready for pickup, launching runner...")
 	logs.Logger.Printf("Command: %s", runnerConfig.Command)
 	logs.Logger.Printf("Args: %v", runnerConfig.Args)
 	logs.Logger.Printf("Env vars: %v", env.Keys(runnerEnv))


### PR DESCRIPTION
This PR allows the launcher to perform a similar handshake with main as the runner but sending a non-expiring offer, and then to wait on an accept of that offer in order to launch the runner, i.e. launching the runner on-demand. 

For now, the runner remains alive and takes any subsequent tasks. In the next PR, the runner will exit if idle and, if this brings the number of runners to zero, the launcher will re-perform the handshake and wait for the next task offer accept.

```
./bin/main javascript
2024/11/19 11:32:35 Started executing `launch` command
2024/11/19 11:32:35 Loaded config file loaded with a single runner config
2024/11/19 11:32:35 Changed into working directory: /Users/ivov/Development/task-runner-launcher/bin
2024/11/19 11:32:35 Filtered environment variables
2024/11/19 11:32:35 Fetched grant token for launcher
2024/11/19 11:32:35 Launcher's runner ID: ebb0d41d246c5efe
2024/11/19 11:32:35 Connected: ws://127.0.0.1:5679/runners/_ws?id=ebb0d41d246c5efe
2024/11/19 11:32:35 <- Received message `broker:inforequest`
2024/11/19 11:32:35 -> Sent message `runner:info`
2024/11/19 11:32:35 <- Received message `broker:runnerregistered`
2024/11/19 11:32:35 -> Sent message `runner:taskoffer` for offer ID `00c2100427bd08cf`
2024/11/19 11:32:35 Waiting for launcher's task offer to be accepted...
2024/11/19 11:32:43 <- Received message `broker:taskofferaccept`
2024/11/19 11:32:43 -> Sent message `runner:taskdeferred` for task ID `msGb5jmF`
2024/11/19 11:32:43 Disconnected: ws://127.0.0.1:5679/runners/_ws?id=ebb0d41d246c5efe
2024/11/19 11:32:43 Task ready for pickup, launching runner...
2024/11/19 11:32:43 Command: /usr/local/bin/node
2024/11/19 11:32:43 Args: [/Users/ivov/Development/n8n/packages/@n8n/task-runner/dist/start.js]
2024/11/19 11:32:43 Env vars: [LANG PATH TERM N8N_RUNNERS_N8N_URI N8N_RUNNERS_GRANT_TOKEN N8N_RUNNERS_GRANT_TOKEN]
```

To be reviewed together with: https://github.com/n8n-io/n8n/pull/11786