### PR TITLE
ci: Configure binary releases for amd64 + arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+on:
+  release:
+    types: [created]
+
+jobs:
+  releases-matrix:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+            
+    steps:
+      - uses: actions/checkout@v4.2.2
+    
+      - uses: wangyoucao577/go-release-action@v1.52
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          goos: ${{ matrix.goos }}
+          goarch: ${{ matrix.goarch }}
+          goversion: 1.23
+          binary_name: task-runner-launcher
+          project_path: ./cmd/launcher
+          sha256sum: true
+          extra_files: README.md LICENSE.md LICENSE_EE.md

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# n8n-launcher
+# task-runner-launcher
 
 CLI utility to launch [n8n task runners](https://docs.n8n.io/PENDING).
 
 ```sh
-./n8n-launcher launch -type javascript
+./task-runner-launcher launch -type javascript
 2024/11/15 13:53:33 Starting to execute `launch` command...
 2024/11/15 13:53:33 Loaded config file loaded with a single runner config
 2024/11/15 13:53:33 Changed into working directory: /Users/ivov/Development/n8n-launcher/bin
@@ -73,7 +73,7 @@ Once setup is complete, start the launcher:
 ```sh
 export N8N_RUNNERS_AUTH_TOKEN=...
 export N8N_RUNNERS_N8N_URI=... 
-./n8n-launcher javascript
+./task-runner-launcher javascript
 ```
 
 ## Development


### PR DESCRIPTION
https://linear.app/n8n/issue/CAT-341/cicd-for-the-go-based-launcher