### PR TITLE
feat: Launch runner on demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Generate a secret auth token (e.g. random string) for the launcher to authentica
 
 ### Idle timeout
 
-If idle for 15 seconds, the runner will exit. To override this duration, set the `N8N_RUNNERS_IDLE_TIMEOUT` to a number of seconds, or `0` to disable it. After runner exit on idle timeout, the launcher will re-launch the runner on demand, i.e. when the next task comes in.   
+If idle for 15 seconds, the runner will exit. To override this duration, set the `N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT` to a number of seconds, or `0` to disable it. After runner exit on idle timeout, the launcher will re-launch the runner on demand, i.e. when the next task comes in.   
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Task runner config fields:
 
 Generate a secret auth token (e.g. random string) for the launcher to authenticate with the n8n main instance. You will need to pass that token as `N8N_RUNNERS_AUTH_TOKEN` to the n8n main instance and to the launcher. During the `launch` command, the launcher will exchange this auth token for a short-lived grant token from the n8n instance, and pass the grant token to the runner.
 
+### Idle timeout
+
+If idle for 15 seconds, the runner will exit. To override this duration, set the `N8N_RUNNERS_IDLE_TIMEOUT` to a number of seconds, or `0` to disable it. After runner exit on idle timeout, the launcher will re-launch the runner on demand, i.e. when the next task comes in.   
+
 ## Usage
 
 Once setup is complete, start the launcher:

--- a/internal/commands/launch.go
+++ b/internal/commands/launch.go
@@ -15,25 +15,26 @@ type LaunchCommand struct {
 	RunnerType string
 }
 
-const defaultIdleTimeout = "15" // seconds
+const idleTimeoutEnvVar = "N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT"
+const defaultIdleTimeoutValue = "15" // seconds
 
 func (l *LaunchCommand) Execute() error {
 	logs.Logger.Println("Started executing `launch` command")
 
 	token := os.Getenv("N8N_RUNNERS_AUTH_TOKEN")
 	n8nURI := os.Getenv("N8N_RUNNERS_N8N_URI")
-	idleTimeout := os.Getenv("N8N_RUNNERS_IDLE_TIMEOUT")
+	idleTimeout := os.Getenv(idleTimeoutEnvVar)
 
 	if token == "" || n8nURI == "" {
 		return fmt.Errorf("both N8N_RUNNERS_AUTH_TOKEN and N8N_RUNNERS_N8N_URI are required")
 	}
 
 	if idleTimeout == "" {
-		os.Setenv("N8N_RUNNERS_IDLE_TIMEOUT", defaultIdleTimeout)
+		os.Setenv(idleTimeoutEnvVar, defaultIdleTimeoutValue)
 	} else {
 		idleTimeoutInt, err := strconv.Atoi(idleTimeout)
 		if err != nil || idleTimeoutInt < 0 {
-			return fmt.Errorf("N8N_RUNNERS_IDLE_TIMEOUT must be a non-negative integer")
+			return fmt.Errorf("N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT must be a non-negative integer")
 		}
 	}
 
@@ -77,7 +78,7 @@ func (l *LaunchCommand) Execute() error {
 
 	// 3. filter environment variables
 
-	defaultEnvs := []string{"LANG", "PATH", "TZ", "TERM", "N8N_RUNNERS_IDLE_TIMEOUT"}
+	defaultEnvs := []string{"LANG", "PATH", "TZ", "TERM", idleTimeoutEnvVar}
 	allowedEnvs := append(defaultEnvs, runnerConfig.AllowedEnv...)
 	runnerEnv := env.AllowedOnly(allowedEnvs)
 

--- a/internal/commands/launch.go
+++ b/internal/commands/launch.go
@@ -57,7 +57,7 @@ func (l *LaunchCommand) Execute() error {
 	}
 
 	if !found {
-		return fmt.Errorf("config file does not contain requested runner type : %s", l.RunnerType)
+		return fmt.Errorf("config file does not contain requested runner type: %s", l.RunnerType)
 	}
 
 	cfgNum := len(cfg.TaskRunners)

--- a/internal/commands/launch.go
+++ b/internal/commands/launch.go
@@ -34,7 +34,7 @@ func (l *LaunchCommand) Execute() error {
 	} else {
 		idleTimeoutInt, err := strconv.Atoi(idleTimeout)
 		if err != nil || idleTimeoutInt < 0 {
-			return fmt.Errorf("N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT must be a non-negative integer")
+			return fmt.Errorf("%s must be a non-negative integer", idleTimeoutEnvVar)
 		}
 	}
 

--- a/internal/commands/launch.go
+++ b/internal/commands/launch.go
@@ -8,20 +8,33 @@ import (
 	"n8n-launcher/internal/logs"
 	"os"
 	"os/exec"
+	"strconv"
 )
 
 type LaunchCommand struct {
 	RunnerType string
 }
 
+const defaultIdleTimeout = "15" // seconds
+
 func (l *LaunchCommand) Execute() error {
 	logs.Logger.Println("Started executing `launch` command")
 
 	token := os.Getenv("N8N_RUNNERS_AUTH_TOKEN")
 	n8nURI := os.Getenv("N8N_RUNNERS_N8N_URI")
+	idleTimeout := os.Getenv("N8N_RUNNERS_IDLE_TIMEOUT")
 
 	if token == "" || n8nURI == "" {
 		return fmt.Errorf("both N8N_RUNNERS_AUTH_TOKEN and N8N_RUNNERS_N8N_URI are required")
+	}
+
+	if idleTimeout == "" {
+		os.Setenv("N8N_RUNNERS_IDLE_TIMEOUT", defaultIdleTimeout)
+	} else {
+		idleTimeoutInt, err := strconv.Atoi(idleTimeout)
+		if err != nil || idleTimeoutInt < 0 {
+			return fmt.Errorf("N8N_RUNNERS_IDLE_TIMEOUT must be a non-negative integer")
+		}
 	}
 
 	// 1. read configuration
@@ -49,7 +62,7 @@ func (l *LaunchCommand) Execute() error {
 	cfgNum := len(cfg.TaskRunners)
 
 	if cfgNum == 1 {
-		logs.Logger.Println("Loaded config file loaded with a single runner config")
+		logs.Logger.Println("Loaded config file with a single runner config")
 	} else {
 		logs.Logger.Printf("Loaded config file with %d runner configs", cfgNum)
 	}
@@ -64,60 +77,62 @@ func (l *LaunchCommand) Execute() error {
 
 	// 3. filter environment variables
 
-	defaultEnvs := []string{"LANG", "PATH", "TZ", "TERM"}
+	defaultEnvs := []string{"LANG", "PATH", "TZ", "TERM", "N8N_RUNNERS_IDLE_TIMEOUT"}
 	allowedEnvs := append(defaultEnvs, runnerConfig.AllowedEnv...)
 	runnerEnv := env.AllowedOnly(allowedEnvs)
 
 	logs.Logger.Printf("Filtered environment variables")
 
-	// 4. fetch grant token for launcher
+	for {
+		// 4. fetch grant token for launcher
 
-	launcherGrantToken, err := auth.FetchGrantToken(n8nURI, token)
-	if err != nil {
-		return fmt.Errorf("failed to fetch grant token for launcher: %w", err)
+		launcherGrantToken, err := auth.FetchGrantToken(n8nURI, token)
+		if err != nil {
+			return fmt.Errorf("failed to fetch grant token for launcher: %w", err)
+		}
+
+		runnerEnv = append(runnerEnv, fmt.Sprintf("N8N_RUNNERS_GRANT_TOKEN=%s", launcherGrantToken))
+
+		logs.Logger.Println("Fetched grant token for launcher")
+
+		// 5. connect to main and wait for task offer to be accepted
+
+		handshakeCfg := auth.HandshakeConfig{
+			TaskType:   l.RunnerType,
+			N8nURI:     n8nURI,
+			GrantToken: launcherGrantToken,
+		}
+
+		if err := auth.Handshake(handshakeCfg); err != nil {
+			return fmt.Errorf("handshake failed: %w", err)
+		}
+
+		// 6. fetch grant token for runner
+
+		runnerGrantToken, err := auth.FetchGrantToken(n8nURI, token)
+		if err != nil {
+			return fmt.Errorf("failed to fetch grant token for runner: %w", err)
+		}
+
+		runnerEnv = append(runnerEnv, fmt.Sprintf("N8N_RUNNERS_GRANT_TOKEN=%s", runnerGrantToken))
+
+		// 7. launch runner
+
+		logs.Logger.Println("Task ready for pickup, launching runner...")
+		logs.Logger.Printf("Command: %s", runnerConfig.Command)
+		logs.Logger.Printf("Args: %v", runnerConfig.Args)
+		logs.Logger.Printf("Env vars: %v", env.Keys(runnerEnv))
+
+		cmd := exec.Command(runnerConfig.Command, runnerConfig.Args...)
+		cmd.Env = runnerEnv
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+
+		err = cmd.Run()
+		if err != nil {
+			return fmt.Errorf("task runner process failed: %w", err)
+		}
+
+		logs.Logger.Printf("Runner exited on idle timeout")
 	}
-
-	runnerEnv = append(runnerEnv, fmt.Sprintf("N8N_RUNNERS_GRANT_TOKEN=%s", launcherGrantToken))
-
-	logs.Logger.Println("Fetched grant token for launcher")
-
-	// 5. connect to main and wait for task offer to be accepted
-
-	handshakeCfg := auth.HandshakeConfig{
-		TaskType:   l.RunnerType,
-		N8nURI:     n8nURI,
-		GrantToken: launcherGrantToken,
-	}
-
-	if err := auth.Handshake(handshakeCfg); err != nil {
-		return fmt.Errorf("handshake failed: %w", err)
-	}
-
-	// 6. fetch grant token for runner
-
-	runnerGrantToken, err := auth.FetchGrantToken(n8nURI, token)
-	if err != nil {
-		return fmt.Errorf("failed to fetch grant token for runner: %w", err)
-	}
-
-	runnerEnv = append(runnerEnv, fmt.Sprintf("N8N_RUNNERS_GRANT_TOKEN=%s", runnerGrantToken))
-
-	// 7. launch runner
-
-	logs.Logger.Println("Task ready for pickup, launching runner...")
-	logs.Logger.Printf("Command: %s", runnerConfig.Command)
-	logs.Logger.Printf("Args: %v", runnerConfig.Args)
-	logs.Logger.Printf("Env vars: %v", env.Keys(runnerEnv))
-
-	cmd := exec.Command(runnerConfig.Command, runnerConfig.Args...)
-	cmd.Env = runnerEnv
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	err = cmd.Run()
-	if err != nil {
-		return fmt.Errorf("failed to launch task runner: %w", err)
-	}
-
-	return nil
 }

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -37,3 +37,16 @@ func Keys(env []string) []string {
 
 	return keys
 }
+
+// Clear removes from a slice of env vars all instances of the given env var.
+func Clear(envVars []string, envVarName string) []string {
+	result := make([]string, 0, len(envVars))
+
+	for _, env := range envVars {
+		if !strings.HasPrefix(env, envVarName+"=") {
+			result = append(result, env)
+		}
+	}
+
+	return result
+}


### PR DESCRIPTION
On runner exit due to idle timeout, the launcher now performs handshake again and waits for next task to arrive.

Story: https://linear.app/n8n/issue/PAY-2246/manage-lifecycle-of-runner

To be reviewed together with: https://github.com/n8n-io/n8n/pull/11820

