### PR TITLE
refactor: Set up env config

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,11 @@ pnpm start
 
 ```sh
 export N8N_LAUNCHER_LOG_LEVEL=debug
-export N8N_RUNNERS_N8N_URI=...        # e.g. http://127.0.0.1:5679
 export N8N_MAIN_URI=...               # e.g. http://127.0.0.1:5678
+export N8N_RUNNERS_N8N_URI=...        # e.g. http://127.0.0.1:5679
+export N8N_RUNNER_URI=...             # e.g. http://127.0.0.1:5680
 export N8N_RUNNERS_AUTH_TOKEN=...     # i.e. same string as in step 4
+export N8N_RUNNERS_SERVER_ENABLED=true
 
 make run
 ```

--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ export N8N_MAIN_URI=...               # e.g. http://127.0.0.1:5678
 export N8N_RUNNERS_N8N_URI=...        # e.g. http://127.0.0.1:5679
 export N8N_RUNNER_URI=...             # e.g. http://127.0.0.1:5680
 export N8N_RUNNERS_AUTH_TOKEN=...     # i.e. same string as in step 4
-export N8N_RUNNERS_SERVER_ENABLED=true
 
 make run
 ```

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ pnpm start
 ```sh
 export N8N_LAUNCHER_LOG_LEVEL=debug
 export N8N_MAIN_URI=...               # e.g. http://127.0.0.1:5678
-export N8N_RUNNERS_N8N_URI=...        # e.g. http://127.0.0.1:5679
+export N8N_TASK_BROKER_URI=...        # e.g. http://127.0.0.1:5679
 export N8N_RUNNER_URI=...             # e.g. http://127.0.0.1:5680
 export N8N_RUNNERS_AUTH_TOKEN=...     # i.e. same string as in step 4
 

--- a/internal/auth/handshake.go
+++ b/internal/auth/handshake.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net/url"
-	"strings"
 	"task-runner-launcher/internal/logs"
 
 	"github.com/gorilla/websocket"
@@ -53,10 +52,6 @@ func validateConfig(cfg HandshakeConfig) error {
 }
 
 func buildWebsocketURL(n8nURI, runnerID string) (*url.URL, error) {
-	if !strings.HasPrefix(n8nURI, "http://") && !strings.HasPrefix(n8nURI, "https://") {
-		n8nURI = "http://" + n8nURI
-	}
-
 	u, err := url.Parse(n8nURI)
 	if err != nil {
 		return nil, fmt.Errorf("invalid n8n URI: %w", err)

--- a/internal/auth/token_exchange.go
+++ b/internal/auth/token_exchange.go
@@ -15,7 +15,7 @@ type grantTokenResponse struct {
 }
 
 func sendGrantTokenRequest(n8nURI, authToken string) (string, error) {
-	url := fmt.Sprintf("http://%s/runners/auth", n8nURI)
+	url := fmt.Sprintf("%s/runners/auth", n8nURI)
 
 	payload := map[string]string{"token": authToken}
 	payloadBytes, err := json.Marshal(payload)

--- a/internal/commands/launch.go
+++ b/internal/commands/launch.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strconv"
 	"task-runner-launcher/internal/auth"
 	"task-runner-launcher/internal/config"
 	"task-runner-launcher/internal/env"
@@ -16,37 +15,19 @@ type LaunchCommand struct {
 	RunnerType string
 }
 
-const idleTimeoutEnvVar = "N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT"
-const defaultIdleTimeoutValue = "15" // seconds
-
 func (l *LaunchCommand) Execute() error {
 	logs.Info("Starting to execute `launch` command")
 
-	authToken := os.Getenv("N8N_RUNNERS_AUTH_TOKEN")
-	n8nRunnerServerURI := os.Getenv("N8N_RUNNERS_N8N_URI")
-	n8nMainServerURI := os.Getenv("N8N_MAIN_URI")
-	idleTimeout := os.Getenv(idleTimeoutEnvVar)
+	// 0. validate env vars
 
-	if authToken == "" || n8nRunnerServerURI == "" {
-		return fmt.Errorf("both N8N_RUNNERS_AUTH_TOKEN and N8N_RUNNERS_N8N_URI are required")
-	}
-
-	if n8nMainServerURI == "" {
-		return fmt.Errorf("N8N_MAIN_URI is required")
-	}
-
-	if idleTimeout == "" {
-		os.Setenv(idleTimeoutEnvVar, defaultIdleTimeoutValue)
-	} else {
-		idleTimeoutInt, err := strconv.Atoi(idleTimeout)
-		if err != nil || idleTimeoutInt < 0 {
-			return fmt.Errorf("%s must be a non-negative integer", idleTimeoutEnvVar)
-		}
+	envCfg, err := env.FromEnv()
+	if err != nil {
+		return fmt.Errorf("env vars failed validation: %w", err)
 	}
 
 	// 1. read configuration
 
-	cfg, err := config.ReadConfig()
+	jsonCfg, err := config.ReadConfig()
 	if err != nil {
 		logs.Errorf("Error reading config: %v", err)
 		return err
@@ -54,7 +35,7 @@ func (l *LaunchCommand) Execute() error {
 
 	var runnerConfig config.TaskRunnerConfig
 	found := false
-	for _, r := range cfg.TaskRunners {
+	for _, r := range jsonCfg.TaskRunners {
 		if r.RunnerType == l.RunnerType {
 			runnerConfig = r
 			found = true
@@ -66,12 +47,12 @@ func (l *LaunchCommand) Execute() error {
 		return fmt.Errorf("config file does not contain requested runner type: %s", l.RunnerType)
 	}
 
-	cfgNum := len(cfg.TaskRunners)
+	jsonCfgNum := len(jsonCfg.TaskRunners)
 
-	if cfgNum == 1 {
+	if jsonCfgNum == 1 {
 		logs.Debug("Loaded config file loaded with a single runner config")
 	} else {
-		logs.Debugf("Loaded config file with %d runner configs", cfgNum)
+		logs.Debugf("Loaded config file with %d runner configs", jsonCfgNum)
 	}
 
 	// 2. change into working directory
@@ -84,7 +65,7 @@ func (l *LaunchCommand) Execute() error {
 
 	// 3. filter environment variables
 
-	defaultEnvs := []string{"LANG", "PATH", "TZ", "TERM", idleTimeoutEnvVar}
+	defaultEnvs := []string{"LANG", "PATH", "TZ", "TERM", env.EnvVarIdleTimeout, env.EnvVarRunnerServerEnabled}
 	allowedEnvs := append(defaultEnvs, runnerConfig.AllowedEnv...)
 	runnerEnv := env.AllowedOnly(allowedEnvs)
 
@@ -92,14 +73,14 @@ func (l *LaunchCommand) Execute() error {
 
 	// 4. wait for n8n instance to be ready
 
-	if err := http.WaitForN8nReady(n8nMainServerURI); err != nil {
+	if err := http.WaitForN8nReady(envCfg.MainServerURI); err != nil {
 		return fmt.Errorf("encountered error while waiting for n8n to be ready: %w", err)
 	}
 
 	for {
 		// 5. fetch grant token for launcher
 
-		launcherGrantToken, err := auth.FetchGrantToken(n8nRunnerServerURI, authToken)
+		launcherGrantToken, err := auth.FetchGrantToken(envCfg.MainRunnerServerURI, envCfg.AuthToken)
 		if err != nil {
 			return fmt.Errorf("failed to fetch grant token for launcher: %w", err)
 		}
@@ -110,7 +91,7 @@ func (l *LaunchCommand) Execute() error {
 
 		handshakeCfg := auth.HandshakeConfig{
 			TaskType:   l.RunnerType,
-			N8nURI:     n8nRunnerServerURI,
+			N8nURI:     envCfg.MainRunnerServerURI,
 			GrantToken: launcherGrantToken,
 		}
 
@@ -120,7 +101,7 @@ func (l *LaunchCommand) Execute() error {
 
 		// 7. fetch grant token for runner
 
-		runnerGrantToken, err := auth.FetchGrantToken(n8nRunnerServerURI, authToken)
+		runnerGrantToken, err := auth.FetchGrantToken(envCfg.MainRunnerServerURI, envCfg.AuthToken)
 		if err != nil {
 			return fmt.Errorf("failed to fetch grant token for runner: %w", err)
 		}
@@ -149,6 +130,6 @@ func (l *LaunchCommand) Execute() error {
 		}
 
 		// next runner will need to fetch a new grant token
-		runnerEnv = env.Clear(runnerEnv, "N8N_RUNNERS_GRANT_TOKEN")
+		runnerEnv = env.Clear(runnerEnv, env.EnvVarGrantToken)
 	}
 }

--- a/internal/commands/launch.go
+++ b/internal/commands/launch.go
@@ -27,15 +27,15 @@ func (l *LaunchCommand) Execute() error {
 
 	// 1. read configuration
 
-	jsonCfg, err := config.ReadConfig()
+	fileCfg, err := config.ReadConfig()
 	if err != nil {
-		logs.Errorf("Error reading config: %v", err)
+		logs.Errorf("Error reading config file: %v", err)
 		return err
 	}
 
 	var runnerConfig config.TaskRunnerConfig
 	found := false
-	for _, r := range jsonCfg.TaskRunners {
+	for _, r := range fileCfg.TaskRunners {
 		if r.RunnerType == l.RunnerType {
 			runnerConfig = r
 			found = true
@@ -47,12 +47,12 @@ func (l *LaunchCommand) Execute() error {
 		return fmt.Errorf("config file does not contain requested runner type: %s", l.RunnerType)
 	}
 
-	jsonCfgNum := len(jsonCfg.TaskRunners)
+	taskRunnersNum := len(fileCfg.TaskRunners)
 
-	if jsonCfgNum == 1 {
+	if taskRunnersNum == 1 {
 		logs.Debug("Loaded config file loaded with a single runner config")
 	} else {
-		logs.Debugf("Loaded config file with %d runner configs", jsonCfgNum)
+		logs.Debugf("Loaded config file with %d runner configs", taskRunnersNum)
 	}
 
 	// 2. change into working directory

--- a/internal/commands/launch.go
+++ b/internal/commands/launch.go
@@ -80,7 +80,7 @@ func (l *LaunchCommand) Execute() error {
 	for {
 		// 5. fetch grant token for launcher
 
-		launcherGrantToken, err := auth.FetchGrantToken(envCfg.MainRunnerServerURI, envCfg.AuthToken)
+		launcherGrantToken, err := auth.FetchGrantToken(envCfg.TaskBrokerServerURI, envCfg.AuthToken)
 		if err != nil {
 			return fmt.Errorf("failed to fetch grant token for launcher: %w", err)
 		}
@@ -91,7 +91,7 @@ func (l *LaunchCommand) Execute() error {
 
 		handshakeCfg := auth.HandshakeConfig{
 			TaskType:   l.RunnerType,
-			N8nURI:     envCfg.MainRunnerServerURI,
+			N8nURI:     envCfg.TaskBrokerServerURI,
 			GrantToken: launcherGrantToken,
 		}
 
@@ -101,7 +101,7 @@ func (l *LaunchCommand) Execute() error {
 
 		// 7. fetch grant token for runner
 
-		runnerGrantToken, err := auth.FetchGrantToken(envCfg.MainRunnerServerURI, envCfg.AuthToken)
+		runnerGrantToken, err := auth.FetchGrantToken(envCfg.TaskBrokerServerURI, envCfg.AuthToken)
 		if err != nil {
 			return fmt.Errorf("failed to fetch grant token for runner: %w", err)
 		}

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -53,7 +53,7 @@ const (
 )
 
 const (
-	defaultIdleTimeoutValue = 15 // seconds
+	defaultIdleTimeoutValue = "15" // seconds
 )
 
 // AllowedOnly filters the current environment down to only those
@@ -137,10 +137,10 @@ func FromEnv() (*Config, error) {
 		errs = append(errs, fmt.Errorf("%s is required to be 'true'", EnvVarRunnerServerEnabled))
 	}
 
-	idleTimeoutInt := defaultIdleTimeoutValue
-	if idleTimeout != "" {
-		var err error
-		idleTimeoutInt, err = strconv.Atoi(idleTimeout)
+	if idleTimeout == "" {
+		os.Setenv(EnvVarIdleTimeout, defaultIdleTimeoutValue)
+	} else {
+		idleTimeoutInt, err := strconv.Atoi(idleTimeout)
 		if err != nil || idleTimeoutInt < 0 {
 			errs = append(errs, fmt.Errorf("%s must be a non-negative integer", EnvVarIdleTimeout))
 		}
@@ -156,6 +156,5 @@ func FromEnv() (*Config, error) {
 		MainRunnerServerURI: mainRunnerServerURI,
 		RunnerServerURI:     runnerServerURI,
 		RunnerServerEnabled: true,
-		IdleTimeout:         idleTimeoutInt,
 	}, nil
 }

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -125,12 +125,15 @@ func FromEnv() (*Config, error) {
 	if authToken == "" {
 		errs = append(errs, fmt.Errorf("%s is required", EnvVarAuthToken))
 	}
+
 	if mainRunnerServerURI == "" {
 		errs = append(errs, fmt.Errorf("%s is required", EnVarTaskBrokerURI))
 	}
+
 	if mainServerURI == "" {
 		errs = append(errs, fmt.Errorf("%s is required", EnvVarMainServerURI))
 	}
+
 	if runnerServerEnabled != "true" {
 		errs = append(errs, fmt.Errorf("%s is required to be 'true'", EnvVarRunnerServerEnabled))
 	}

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -31,9 +31,9 @@ const (
 	// main server.
 	EnvVarMainServerURI = "N8N_MAIN_URI"
 
-	// EnVarTaskBrokerURI is the env var for the URI of the n8n main
+	// EnVarTaskBrokerServerURI is the env var for the URI of the n8n main
 	// instance's runner server.
-	EnVarTaskBrokerURI = "N8N_TASK_BROKER_URI"
+	EnVarTaskBrokerServerURI = "N8N_TASK_BROKER_URI"
 
 	// ------------------------
 	//         runner
@@ -117,7 +117,7 @@ func FromEnv() (*Config, error) {
 
 	authToken := os.Getenv(EnvVarAuthToken)
 	mainServerURI := os.Getenv(EnvVarMainServerURI)
-	mainRunnerServerURI := os.Getenv(EnVarTaskBrokerURI)
+	taskBrokerServerURI := os.Getenv(EnVarTaskBrokerServerURI)
 	runnerServerURI := os.Getenv(EnvVarRunnerServerURI)
 	runnerServerEnabled := os.Getenv(EnvVarRunnerServerEnabled)
 	idleTimeout := os.Getenv(EnvVarIdleTimeout)
@@ -126,8 +126,8 @@ func FromEnv() (*Config, error) {
 		errs = append(errs, fmt.Errorf("%s is required", EnvVarAuthToken))
 	}
 
-	if mainRunnerServerURI == "" {
-		errs = append(errs, fmt.Errorf("%s is required", EnVarTaskBrokerURI))
+	if taskBrokerServerURI == "" {
+		errs = append(errs, fmt.Errorf("%s is required", EnVarTaskBrokerServerURI))
 	}
 
 	if mainServerURI == "" {
@@ -156,7 +156,7 @@ func FromEnv() (*Config, error) {
 	return &Config{
 		AuthToken:           authToken,
 		MainServerURI:       mainServerURI,
-		MainRunnerServerURI: mainRunnerServerURI,
+		MainRunnerServerURI: taskBrokerServerURI,
 		RunnerServerURI:     runnerServerURI,
 	}, nil
 }

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -108,8 +108,6 @@ type Config struct {
 	MainServerURI       string
 	MainRunnerServerURI string
 	RunnerServerURI     string
-	RunnerServerEnabled bool
-	IdleTimeout         int
 }
 
 // FromEnv retrieves vars from the environment, validates their values, and
@@ -150,11 +148,12 @@ func FromEnv() (*Config, error) {
 		return nil, errors.Join(errs...)
 	}
 
+	os.Setenv(EnvVarRunnerServerEnabled, "true")
+
 	return &Config{
 		AuthToken:           authToken,
 		MainServerURI:       mainServerURI,
 		MainRunnerServerURI: mainRunnerServerURI,
 		RunnerServerURI:     runnerServerURI,
-		RunnerServerEnabled: true,
 	}, nil
 }

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -29,11 +29,11 @@ const (
 	// ------------------------
 
 	// EnvVarMainServerURI is the env var for the URI of the n8n main instance's
-	// main server.
+	// main server, typically at http://127.0.0.1:5678.
 	EnvVarMainServerURI = "N8N_MAIN_URI"
 
 	// EnVarTaskBrokerServerURI is the env var for the URI of the n8n main
-	// instance's runner server.
+	// instance's task broker server, typically at http://127.0.0.1:5679.
 	EnVarTaskBrokerServerURI = "N8N_TASK_BROKER_URI"
 
 	// ------------------------
@@ -41,7 +41,7 @@ const (
 	// ------------------------
 
 	// EnvVarRunnerServerURI is the env var for the URI of the runner's server.
-	// Used for monitoring the runner's health.
+	// Used for monitoring the runner's health, typically at http://127.0.0.1:5680.
 	EnvVarRunnerServerURI = "N8N_RUNNER_URI"
 
 	// EnvVarRunnerServerEnabled is the env var for whether the runner's health
@@ -107,7 +107,7 @@ func Clear(envVars []string, envVarName string) []string {
 type Config struct {
 	AuthToken           string
 	MainServerURI       string
-	MainRunnerServerURI string
+	TaskBrokerServerURI string
 	RunnerServerURI     string
 }
 
@@ -126,16 +126,22 @@ func FromEnv() (*Config, error) {
 		errs = append(errs, fmt.Errorf("%s is required", EnvVarAuthToken))
 	}
 
-	if taskBrokerServerURI == "" {
-		errs = append(errs, fmt.Errorf("%s is required", EnVarTaskBrokerServerURI))
-	} else if _, err := url.Parse(taskBrokerServerURI); err != nil {
-		errs = append(errs, fmt.Errorf("%s must be a valid URL: %w", EnVarTaskBrokerServerURI, err))
-	}
-
 	if mainServerURI == "" {
 		errs = append(errs, fmt.Errorf("%s is required", EnvVarMainServerURI))
 	} else if _, err := url.Parse(mainServerURI); err != nil {
 		errs = append(errs, fmt.Errorf("%s must be a valid URL: %w", EnvVarMainServerURI, err))
+	}
+
+	if runnerServerURI == "" {
+		errs = append(errs, fmt.Errorf("%s is required", EnvVarRunnerServerURI))
+	} else if _, err := url.Parse(runnerServerURI); err != nil {
+		errs = append(errs, fmt.Errorf("%s must be a valid URL: %w", EnvVarRunnerServerURI, err))
+	}
+
+	if taskBrokerServerURI == "" {
+		errs = append(errs, fmt.Errorf("%s is required", EnVarTaskBrokerServerURI))
+	} else if _, err := url.Parse(taskBrokerServerURI); err != nil {
+		errs = append(errs, fmt.Errorf("%s must be a valid URL: %w", EnVarTaskBrokerServerURI, err))
 	}
 
 	if idleTimeout == "" {
@@ -156,7 +162,7 @@ func FromEnv() (*Config, error) {
 	return &Config{
 		AuthToken:           authToken,
 		MainServerURI:       mainServerURI,
-		MainRunnerServerURI: taskBrokerServerURI,
+		TaskBrokerServerURI: taskBrokerServerURI,
 		RunnerServerURI:     runnerServerURI,
 	}, nil
 }

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -40,7 +40,7 @@ const (
 	// ------------------------
 
 	// EnvVarRunnerServerURI is the env var for the URI of the runner's server. Do not
-	// confuse with `N8N_RUNNERS_N8N_URI`.
+	// confuse with `N8N_RUNNERS_N8N_URI`. Used for monitoring the runner's health
 	EnvVarRunnerServerURI = "N8N_RUNNER_URI"
 
 	// EnvVarRunnerServerEnabled is the env var for whether the runner's health

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -32,15 +32,15 @@ const (
 	EnvVarMainServerURI = "N8N_MAIN_URI"
 
 	// EnVarTaskBrokerURI is the env var for the URI of the n8n main
-	// instance's runner server. Do not confuse with `N8N_RUNNER_URI`.
+	// instance's runner server.
 	EnVarTaskBrokerURI = "N8N_TASK_BROKER_URI"
 
 	// ------------------------
 	//         runner
 	// ------------------------
 
-	// EnvVarRunnerServerURI is the env var for the URI of the runner's server. Do not
-	// confuse with `N8N_RUNNERS_N8N_URI`. Used for monitoring the runner's health
+	// EnvVarRunnerServerURI is the env var for the URI of the runner's server.
+	// Used for monitoring the runner's health.
 	EnvVarRunnerServerURI = "N8N_RUNNER_URI"
 
 	// EnvVarRunnerServerEnabled is the env var for whether the runner's health

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -31,9 +31,9 @@ const (
 	// main server.
 	EnvVarMainServerURI = "N8N_MAIN_URI"
 
-	// EnvVarMainRunnerServerURI is the env var for the URI of the n8n main
+	// EnVarTaskBrokerURI is the env var for the URI of the n8n main
 	// instance's runner server. Do not confuse with `N8N_RUNNER_URI`.
-	EnvVarMainRunnerServerURI = "N8N_RUNNERS_N8N_URI"
+	EnVarTaskBrokerURI = "N8N_TASK_BROKER_URI"
 
 	// ------------------------
 	//         runner
@@ -117,7 +117,7 @@ func FromEnv() (*Config, error) {
 
 	authToken := os.Getenv(EnvVarAuthToken)
 	mainServerURI := os.Getenv(EnvVarMainServerURI)
-	mainRunnerServerURI := os.Getenv(EnvVarMainRunnerServerURI)
+	mainRunnerServerURI := os.Getenv(EnVarTaskBrokerURI)
 	runnerServerURI := os.Getenv(EnvVarRunnerServerURI)
 	runnerServerEnabled := os.Getenv(EnvVarRunnerServerEnabled)
 	idleTimeout := os.Getenv(EnvVarIdleTimeout)
@@ -126,7 +126,7 @@ func FromEnv() (*Config, error) {
 		errs = append(errs, fmt.Errorf("%s is required", EnvVarAuthToken))
 	}
 	if mainRunnerServerURI == "" {
-		errs = append(errs, fmt.Errorf("%s is required", EnvVarMainRunnerServerURI))
+		errs = append(errs, fmt.Errorf("%s is required", EnVarTaskBrokerURI))
 	}
 	if mainServerURI == "" {
 		errs = append(errs, fmt.Errorf("%s is required", EnvVarMainServerURI))

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -120,7 +120,6 @@ func FromEnv() (*Config, error) {
 	mainServerURI := os.Getenv(EnvVarMainServerURI)
 	taskBrokerServerURI := os.Getenv(EnVarTaskBrokerServerURI)
 	runnerServerURI := os.Getenv(EnvVarRunnerServerURI)
-	runnerServerEnabled := os.Getenv(EnvVarRunnerServerEnabled)
 	idleTimeout := os.Getenv(EnvVarIdleTimeout)
 
 	if authToken == "" {
@@ -137,10 +136,6 @@ func FromEnv() (*Config, error) {
 		errs = append(errs, fmt.Errorf("%s is required", EnvVarMainServerURI))
 	} else if _, err := url.Parse(mainServerURI); err != nil {
 		errs = append(errs, fmt.Errorf("%s must be a valid URL: %w", EnvVarMainServerURI, err))
-	}
-
-	if runnerServerEnabled != "true" {
-		errs = append(errs, fmt.Errorf("%s is required to be 'true'", EnvVarRunnerServerEnabled))
 	}
 
 	if idleTimeout == "" {

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -3,6 +3,7 @@ package env
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -128,10 +129,14 @@ func FromEnv() (*Config, error) {
 
 	if taskBrokerServerURI == "" {
 		errs = append(errs, fmt.Errorf("%s is required", EnVarTaskBrokerServerURI))
+	} else if _, err := url.Parse(taskBrokerServerURI); err != nil {
+		errs = append(errs, fmt.Errorf("%s must be a valid URL: %w", EnVarTaskBrokerServerURI, err))
 	}
 
 	if mainServerURI == "" {
 		errs = append(errs, fmt.Errorf("%s is required", EnvVarMainServerURI))
+	} else if _, err := url.Parse(mainServerURI); err != nil {
+		errs = append(errs, fmt.Errorf("%s must be a valid URL: %w", EnvVarMainServerURI, err))
 	}
 
 	if runnerServerEnabled != "true" {

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -32,14 +32,14 @@ const (
 	EnvVarMainServerURI = "N8N_MAIN_URI"
 
 	// EnvVarMainRunnerServerURI is the env var for the URI of the n8n main
-	// instance's runner server.
+	// instance's runner server. Do not confuse with `N8N_RUNNER_URI`.
 	EnvVarMainRunnerServerURI = "N8N_RUNNERS_N8N_URI"
 
 	// ------------------------
 	//         runner
 	// ------------------------
 
-	// EnvVarRunnerServerURI is the env var for the n8n runner server URI. Do not
+	// EnvVarRunnerServerURI is the env var for the URI of the runner's server. Do not
 	// confuse with `N8N_RUNNERS_N8N_URI`.
 	EnvVarRunnerServerURI = "N8N_RUNNER_URI"
 

--- a/internal/http/wait_for_n8n.go
+++ b/internal/http/wait_for_n8n.go
@@ -3,19 +3,13 @@ package http
 import (
 	"fmt"
 	"net/http"
-	"strings"
 	"task-runner-launcher/internal/logs"
 	"task-runner-launcher/internal/retry"
 	"time"
 )
 
 func sendReadinessRequest(n8nMainServerURI string) (*http.Response, error) {
-	baseURL := n8nMainServerURI
-	if !strings.HasPrefix(n8nMainServerURI, "http://") && !strings.HasPrefix(n8nMainServerURI, "https://") {
-		baseURL = "http://" + n8nMainServerURI
-	}
-
-	url := fmt.Sprintf("%s/healthz/readiness", baseURL)
+	url := fmt.Sprintf("%s/healthz/readiness", n8nMainServerURI)
 
 	client := &http.Client{
 		Timeout: 5 * time.Second,


### PR DESCRIPTION
This PR is setup for runner health monitoring to be done at https://linear.app/n8n/issue/PAY-2280

- Move all env retrieval and validation to the `env` package
- Add `N8N_RUNNERS_SERVER_ENABLED` and `N8N_RUNNER_URI` to required envs
- Set up constants for all env var names