### PR TITLE
feat: Set sane defaults for all URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,6 @@ pnpm start
 
 ```sh
 export N8N_LAUNCHER_LOG_LEVEL=debug
-export N8N_MAIN_URI=...               # e.g. http://127.0.0.1:5678
-export N8N_TASK_BROKER_URI=...        # e.g. http://127.0.0.1:5679
-export N8N_RUNNER_URI=...             # e.g. http://127.0.0.1:5680
 export N8N_RUNNERS_AUTH_TOKEN=...     # i.e. same string as in step 4
 
 make run

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -54,7 +54,10 @@ const (
 )
 
 const (
-	defaultIdleTimeoutValue = "15" // seconds
+	defaultIdleTimeoutValue    = "15" // seconds
+	DefaultMainServerUri       = "http://127.0.0.1:5678"
+	DefaultTaskBrokerServerUri = "http://127.0.0.1:5679"
+	DefaultRunnerServerUri     = "http://127.0.0.1:5680"
 )
 
 // AllowedOnly filters the current environment down to only those
@@ -143,19 +146,19 @@ func FromEnv() (*EnvConfig, error) {
 	}
 
 	if mainServerURI == "" {
-		errs = append(errs, fmt.Errorf("%s is required", EnvVarMainServerURI))
+		mainServerURI = DefaultMainServerUri
 	} else if err := validateURL(mainServerURI, EnvVarMainServerURI); err != nil {
 		errs = append(errs, err)
 	}
 
 	if runnerServerURI == "" {
-		errs = append(errs, fmt.Errorf("%s is required", EnvVarRunnerServerURI))
+		runnerServerURI = DefaultRunnerServerUri
 	} else if err := validateURL(runnerServerURI, EnvVarRunnerServerURI); err != nil {
 		errs = append(errs, err)
 	}
 
 	if taskBrokerServerURI == "" {
-		errs = append(errs, fmt.Errorf("%s is required", EnvVarTaskBrokerServerURI))
+		taskBrokerServerURI = DefaultTaskBrokerServerUri
 	} else if err := validateURL(taskBrokerServerURI, EnvVarTaskBrokerServerURI); err != nil {
 		errs = append(errs, err)
 	}

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -55,9 +55,9 @@ const (
 
 const (
 	defaultIdleTimeoutValue    = "15" // seconds
-	DefaultMainServerUri       = "http://127.0.0.1:5678"
-	DefaultTaskBrokerServerUri = "http://127.0.0.1:5679"
-	DefaultRunnerServerUri     = "http://127.0.0.1:5680"
+	DefaultMainServerURI       = "http://127.0.0.1:5678"
+	DefaultTaskBrokerServerURI = "http://127.0.0.1:5679"
+	DefaultRunnerServerURI     = "http://127.0.0.1:5680"
 )
 
 // AllowedOnly filters the current environment down to only those
@@ -146,19 +146,19 @@ func FromEnv() (*EnvConfig, error) {
 	}
 
 	if mainServerURI == "" {
-		mainServerURI = DefaultMainServerUri
+		mainServerURI = DefaultMainServerURI
 	} else if err := validateURL(mainServerURI, EnvVarMainServerURI); err != nil {
 		errs = append(errs, err)
 	}
 
 	if runnerServerURI == "" {
-		runnerServerURI = DefaultRunnerServerUri
+		runnerServerURI = DefaultRunnerServerURI
 	} else if err := validateURL(runnerServerURI, EnvVarRunnerServerURI); err != nil {
 		errs = append(errs, err)
 	}
 
 	if taskBrokerServerURI == "" {
-		taskBrokerServerURI = DefaultTaskBrokerServerUri
+		taskBrokerServerURI = DefaultTaskBrokerServerURI
 	} else if err := validateURL(taskBrokerServerURI, EnvVarTaskBrokerServerURI); err != nil {
 		errs = append(errs, err)
 	}

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -194,7 +194,7 @@ func TestFromEnv(t *testing.T) {
 			},
 			expected: &EnvConfig{
 				AuthToken:           "token123",
-				MainServerURI:       DefaultMainServerUri,
+				MainServerURI:       DefaultMainServerURI,
 				TaskBrokerServerURI: "http://localhost:5679",
 				RunnerServerURI:     "http://localhost:5680",
 			},
@@ -219,7 +219,7 @@ func TestFromEnv(t *testing.T) {
 			expected: &EnvConfig{
 				AuthToken:           "token123",
 				MainServerURI:       "http://localhost:5678",
-				TaskBrokerServerURI: DefaultTaskBrokerServerUri,
+				TaskBrokerServerURI: DefaultTaskBrokerServerURI,
 				RunnerServerURI:     "http://localhost:5680",
 			},
 		},
@@ -244,7 +244,7 @@ func TestFromEnv(t *testing.T) {
 				AuthToken:           "token123",
 				MainServerURI:       "http://localhost:5678",
 				TaskBrokerServerURI: "http://localhost:5679",
-				RunnerServerURI:     DefaultRunnerServerUri,
+				RunnerServerURI:     DefaultRunnerServerURI,
 			},
 		},
 		{

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -148,17 +148,23 @@ func TestFromEnv(t *testing.T) {
 		name        string
 		envVars     map[string]string
 		expectError bool
+		expected    *EnvConfig
 	}{
 		{
 			name: "valid configuration",
 			envVars: map[string]string{
 				EnvVarAuthToken:           "token123",
-				EnvVarMainServerURI:       "http://localhost:5678",
-				EnvVarTaskBrokerServerURI: "http://localhost:5679",
-				EnvVarRunnerServerURI:     "http://localhost:5680",
+				EnvVarMainServerURI:       "http://localhost:9000",
+				EnvVarTaskBrokerServerURI: "http://localhost:9001",
+				EnvVarRunnerServerURI:     "http://localhost:9002",
 				EnvVarIdleTimeout:         "30",
 			},
-			expectError: false,
+			expected: &EnvConfig{
+				AuthToken:           "token123",
+				MainServerURI:       "http://localhost:9000",
+				TaskBrokerServerURI: "http://localhost:9001",
+				RunnerServerURI:     "http://localhost:9002",
+			},
 		},
 		{
 			name: "missing auth token",
@@ -186,7 +192,12 @@ func TestFromEnv(t *testing.T) {
 				EnvVarTaskBrokerServerURI: "http://localhost:5679",
 				EnvVarRunnerServerURI:     "http://localhost:5680",
 			},
-			expectError: true,
+			expected: &EnvConfig{
+				AuthToken:           "token123",
+				MainServerURI:       DefaultMainServerUri,
+				TaskBrokerServerURI: "http://localhost:5679",
+				RunnerServerURI:     "http://localhost:5680",
+			},
 		},
 		{
 			name: "invalid task broker server URI",
@@ -205,7 +216,12 @@ func TestFromEnv(t *testing.T) {
 				EnvVarMainServerURI:   "http://localhost:5678",
 				EnvVarRunnerServerURI: "http://localhost:5680",
 			},
-			expectError: true,
+			expected: &EnvConfig{
+				AuthToken:           "token123",
+				MainServerURI:       "http://localhost:5678",
+				TaskBrokerServerURI: DefaultTaskBrokerServerUri,
+				RunnerServerURI:     "http://localhost:5680",
+			},
 		},
 		{
 			name: "invalid runner server URI",
@@ -224,7 +240,12 @@ func TestFromEnv(t *testing.T) {
 				EnvVarMainServerURI:       "http://localhost:5678",
 				EnvVarTaskBrokerServerURI: "http://localhost:5679",
 			},
-			expectError: true,
+			expected: &EnvConfig{
+				AuthToken:           "token123",
+				MainServerURI:       "http://localhost:5678",
+				TaskBrokerServerURI: "http://localhost:5679",
+				RunnerServerURI:     DefaultRunnerServerUri,
+			},
 		},
 		{
 			name: "missing scheme in 127.0.0.1 URI",
@@ -296,20 +317,8 @@ func TestFromEnv(t *testing.T) {
 				return
 			}
 
-			if envCfg.AuthToken != tt.envVars[EnvVarAuthToken] {
-				t.Errorf("FromEnv() AuthToken = %v, want %v", envCfg.AuthToken, tt.envVars[EnvVarAuthToken])
-			}
-
-			if envCfg.MainServerURI != tt.envVars[EnvVarMainServerURI] {
-				t.Errorf("FromEnv() MainServerURI = %v, want %v", envCfg.MainServerURI, tt.envVars[EnvVarMainServerURI])
-			}
-
-			if envCfg.TaskBrokerServerURI != tt.envVars[EnvVarTaskBrokerServerURI] {
-				t.Errorf("FromEnv() TaskBrokerServerURI = %v, want %v", envCfg.TaskBrokerServerURI, tt.envVars[EnvVarTaskBrokerServerURI])
-			}
-
-			if envCfg.RunnerServerURI != tt.envVars[EnvVarRunnerServerURI] {
-				t.Errorf("FromEnv() RunnerServerURI = %v, want %v", envCfg.RunnerServerURI, tt.envVars[EnvVarRunnerServerURI])
+			if !reflect.DeepEqual(envCfg, tt.expected) {
+				t.Errorf("FromEnv() = %+v, want %+v", envCfg, tt.expected)
 			}
 
 			if os.Getenv(EnvVarRunnerServerEnabled) != "true" {

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -151,7 +151,7 @@ func TestFromEnv(t *testing.T) {
 		expected    *EnvConfig
 	}{
 		{
-			name: "valid configuration",
+			name: "valid custom configuration",
 			envVars: map[string]string{
 				EnvVarAuthToken:           "token123",
 				EnvVarMainServerURI:       "http://localhost:9000",


### PR DESCRIPTION
This PR introduces sane defaults for all three URIs when not defined:

- n8n main's regular server → `http://127.0.0.1:5678`
- n8n main's task broker server → `http://127.0.0.1:5679`
- task runner's health check server → `http://127.0.0.1:5680`

This allows us to minimize the config we need to pass into cloud instances.