### PR TITLE
refactor: Normalize runner logs

### DIFF
--- a/internal/commands/launch.go
+++ b/internal/commands/launch.go
@@ -124,8 +124,7 @@ func (l *LaunchCommand) Execute() error {
 
 		cmd := exec.CommandContext(ctx, runnerCfg.Command, runnerCfg.Args...)
 		cmd.Env = runnerEnv
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
+		cmd.Stdout, cmd.Stderr = logs.GetRunnerWriters()
 
 		if err := cmd.Start(); err != nil {
 			cancelHealthMonitor()

--- a/internal/logs/runner_writers.go
+++ b/internal/logs/runner_writers.go
@@ -1,0 +1,54 @@
+package logs
+
+import (
+	"bufio"
+	"io"
+	"log"
+	"os"
+	"strings"
+)
+
+// RunnerWriter wraps runner output with timestamps and prefixes.
+type RunnerWriter struct {
+	writer *log.Logger
+	prefix string
+	level  string
+	color  string
+}
+
+// NewRunnerWriter creates a new wrapper for runner output.
+func NewRunnerWriter(w io.Writer, prefix string, level string, color string) *RunnerWriter {
+	return &RunnerWriter{
+		writer: log.New(w, "", log.LstdFlags),
+		prefix: prefix,
+		level:  level,
+		color:  color,
+	}
+}
+
+// Write implements `io.Writer` and adds color, timestamp, level and a prefix to each line.
+func (w *RunnerWriter) Write(p []byte) (n int, err error) {
+	scanner := bufio.NewScanner(strings.NewReader(string(p)))
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		w.writer.Printf("%s%s %s%s%s", w.color, w.level, w.prefix, line, colorReset)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return 0, err
+	}
+
+	return len(p), nil
+}
+
+// GetRunnerWriters returns configured `stdout` and `stderr` writers for a runner.
+func GetRunnerWriters() (stdout io.Writer, stderr io.Writer) {
+	stdout = NewRunnerWriter(os.Stdout, "[Runner] ", "DEBUG", colorCyan)
+	stderr = NewRunnerWriter(os.Stderr, "[Runner] ", "ERROR", colorRed)
+
+	return stdout, stderr
+}


### PR DESCRIPTION
This PR normalizes runner logs to align with launcher logs. See [before](https://share.cleanshot.com/psfDp8fQ) and [after](https://share.cleanshot.com/tDyC0YjN).