### PR TITLE
feat: Stay active on n8n instance crash

### DIFF
--- a/internal/auth/handshake.go
+++ b/internal/auth/handshake.go
@@ -5,7 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net/url"
-	"task-runner-launcher/internal/launcherr"
+	"task-runner-launcher/internal/errs"
 	"task-runner-launcher/internal/logs"
 
 	"github.com/gorilla/websocket"
@@ -132,9 +132,9 @@ func Handshake(cfg HandshakeConfig) error {
 			if err != nil {
 				switch {
 				case websocket.IsCloseError(err, websocket.CloseGoingAway):
-					errReceived <- launcherr.ErrServerDown
+					errReceived <- errs.ErrServerDown
 				case err == websocket.ErrReadLimit:
-					errReceived <- launcherr.ErrWsMsgTooLarge
+					errReceived <- errs.ErrWsMsgTooLarge
 				default:
 					errReceived <- fmt.Errorf("failed to read ws message: %w", err)
 				}

--- a/internal/auth/handshake.go
+++ b/internal/auth/handshake.go
@@ -98,6 +98,11 @@ func randomID() string {
 	return hex.EncodeToString(b)
 }
 
+func isWsCloseError(err error) bool {
+	_, ok := err.(*websocket.CloseError)
+	return ok
+}
+
 // Handshake is the flow where the launcher connects via websocket with main,
 // registers with main's task broker, sends a non-expiring task offer to main, and
 // receives the accept for that offer from main. Note that the handshake completes
@@ -131,7 +136,7 @@ func Handshake(cfg HandshakeConfig) error {
 			err := wsConn.ReadJSON(&msg)
 			if err != nil {
 				switch {
-				case websocket.IsCloseError(err, websocket.CloseGoingAway):
+				case isWsCloseError(err):
 					errReceived <- errs.ErrServerDown
 				case err == websocket.ErrReadLimit:
 					errReceived <- errs.ErrWsMsgTooLarge

--- a/internal/commands/launch.go
+++ b/internal/commands/launch.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -10,7 +11,9 @@ import (
 	"task-runner-launcher/internal/config"
 	"task-runner-launcher/internal/env"
 	"task-runner-launcher/internal/http"
+	"task-runner-launcher/internal/launcherr"
 	"task-runner-launcher/internal/logs"
+	"time"
 )
 
 type LaunchCommand struct {
@@ -73,13 +76,13 @@ func (l *LaunchCommand) Execute() error {
 
 	logs.Debugf("Filtered environment variables")
 
-	// 4. wait for n8n instance to be ready
-
-	if err := http.WaitForN8nReady(envCfg.MainServerURI); err != nil {
-		return fmt.Errorf("encountered error while waiting for n8n to be ready: %w", err)
-	}
-
 	for {
+		// 4. check until n8n instance is ready
+
+		if err := http.CheckUntilN8nReady(envCfg.MainServerURI); err != nil {
+			return fmt.Errorf("encountered error while waiting for n8n to be ready: %w", err)
+		}
+
 		// 5. fetch grant token for launcher
 
 		launcherGrantToken, err := auth.FetchGrantToken(envCfg.TaskBrokerServerURI, envCfg.AuthToken)
@@ -97,7 +100,13 @@ func (l *LaunchCommand) Execute() error {
 			GrantToken:          launcherGrantToken,
 		}
 
-		if err := auth.Handshake(handshakeCfg); err != nil {
+		err = auth.Handshake(handshakeCfg)
+		switch {
+		case errors.Is(err, launcherr.ErrServerDown):
+			logs.Warn("n8n is down, launcher will try to reconnect...")
+			time.Sleep(time.Second * 5)
+			continue // back to checking until n8n ready
+		case err != nil:
 			return fmt.Errorf("handshake failed: %w", err)
 		}
 

--- a/internal/commands/launch.go
+++ b/internal/commands/launch.go
@@ -10,8 +10,8 @@ import (
 	"task-runner-launcher/internal/auth"
 	"task-runner-launcher/internal/config"
 	"task-runner-launcher/internal/env"
+	"task-runner-launcher/internal/errs"
 	"task-runner-launcher/internal/http"
-	"task-runner-launcher/internal/launcherr"
 	"task-runner-launcher/internal/logs"
 	"time"
 )
@@ -102,7 +102,7 @@ func (l *LaunchCommand) Execute() error {
 
 		err = auth.Handshake(handshakeCfg)
 		switch {
-		case errors.Is(err, launcherr.ErrServerDown):
+		case errors.Is(err, errs.ErrServerDown):
 			logs.Warn("n8n is down, launcher will try to reconnect...")
 			time.Sleep(time.Second * 5)
 			continue // back to checking until n8n ready

--- a/internal/errs/errs.go
+++ b/internal/errs/errs.go
@@ -1,4 +1,4 @@
-package launcherr
+package errs
 
 import "errors"
 

--- a/internal/http/wait_for_n8n.go
+++ b/internal/http/wait_for_n8n.go
@@ -23,10 +23,10 @@ func sendReadinessRequest(n8nMainServerURI string) (*http.Response, error) {
 	return client.Do(req)
 }
 
-// WaitForN8nReady checks forever until the n8n main instance is ready, i.e.
+// CheckUntilN8nReady checks forever until the n8n main instance is ready, i.e.
 // until its DB is connected and migrated. In case of long-running migrations,
 // readiness may take a long time. Returns nil when ready.
-func WaitForN8nReady(n8nMainServerURI string) error {
+func CheckUntilN8nReady(n8nMainServerURI string) error {
 	logs.Info("Waiting for n8n to be ready...")
 
 	readinessCheck := func() (string, error) {

--- a/internal/launcherr/launcherr.go
+++ b/internal/launcherr/launcherr.go
@@ -3,10 +3,6 @@ package launcherr
 import "errors"
 
 var (
-	// ErrServerGoingAway is returned when the n8n server closes the launcher's
-	// websocket connection with status code 1001.
-	ErrServerGoingAway = errors.New("websocket connection closed by server going away")
-
 	// ErrServerDown is returned when the n8n runner server is down.
 	ErrServerDown = errors.New("n8n runner server is down")
 

--- a/internal/launcherr/launcherr.go
+++ b/internal/launcherr/launcherr.go
@@ -1,0 +1,16 @@
+package launcherr
+
+import "errors"
+
+var (
+	// ErrServerGoingAway is returned when the n8n server closes the launcher's
+	// websocket connection with status code 1001.
+	ErrServerGoingAway = errors.New("websocket connection closed by server going away")
+
+	// ErrServerDown is returned when the n8n runner server is down.
+	ErrServerDown = errors.New("n8n runner server is down")
+
+	// ErrWsMsgTooLarge is returned when the websocket message is too large for
+	// the launcher's websocket buffer.
+	ErrWsMsgTooLarge = errors.New("websocket message too large for buffer - please increase buffer size")
+)


### PR DESCRIPTION
This PR ensures the launcher process stays active during an n8n instance crash and tries to reconnect once n8n is back up again.

https://linear.app/n8n/issue/CAT-352