### PR TITLE
refactor: Organize `internal` dir

### DIFF
--- a/internal/commands/command.go
+++ b/internal/commands/command.go
@@ -1,5 +1,0 @@
-package commands
-
-type Command interface {
-	Execute() error
-}

--- a/internal/commands/launch.go
+++ b/internal/commands/launch.go
@@ -13,6 +13,10 @@ import (
 	"task-runner-launcher/internal/ws"
 )
 
+type Command interface {
+	Execute() error
+}
+
 type LaunchCommand struct {
 	RunnerType string
 }

--- a/internal/commands/launch.go
+++ b/internal/commands/launch.go
@@ -79,7 +79,7 @@ func (l *LaunchCommand) Execute() error {
 
 	// 4. wait for n8n instance to be ready
 
-	if err := http.WaitForN8nReady(envCfg.MainServerURI); err != nil {
+	if err := http.CheckUntilN8nReady(envCfg.MainServerURI); err != nil {
 		return fmt.Errorf("encountered error while waiting for n8n to be ready: %w", err)
 	}
 

--- a/internal/commands/launch.go
+++ b/internal/commands/launch.go
@@ -6,11 +6,11 @@ import (
 	"os"
 	"os/exec"
 	"sync"
-	"task-runner-launcher/internal/auth"
 	"task-runner-launcher/internal/config"
 	"task-runner-launcher/internal/env"
 	"task-runner-launcher/internal/http"
 	"task-runner-launcher/internal/logs"
+	"task-runner-launcher/internal/ws"
 )
 
 type LaunchCommand struct {
@@ -91,13 +91,13 @@ func (l *LaunchCommand) Execute() error {
 
 		// 6. connect to main and wait for task offer to be accepted
 
-		handshakeCfg := auth.HandshakeConfig{
+		handshakeCfg := ws.HandshakeConfig{
 			TaskType:            l.RunnerType,
 			TaskBrokerServerURI: envCfg.TaskBrokerServerURI,
 			GrantToken:          launcherGrantToken,
 		}
 
-		if err := auth.Handshake(handshakeCfg); err != nil {
+		if err := ws.Handshake(handshakeCfg); err != nil {
 			return fmt.Errorf("handshake failed: %w", err)
 		}
 

--- a/internal/commands/launch.go
+++ b/internal/commands/launch.go
@@ -82,7 +82,7 @@ func (l *LaunchCommand) Execute() error {
 	for {
 		// 5. fetch grant token for launcher
 
-		launcherGrantToken, err := auth.FetchGrantToken(envCfg.TaskBrokerServerURI, envCfg.AuthToken)
+		launcherGrantToken, err := http.FetchGrantToken(envCfg.TaskBrokerServerURI, envCfg.AuthToken)
 		if err != nil {
 			return fmt.Errorf("failed to fetch grant token for launcher: %w", err)
 		}
@@ -103,7 +103,7 @@ func (l *LaunchCommand) Execute() error {
 
 		// 7. fetch grant token for runner
 
-		runnerGrantToken, err := auth.FetchGrantToken(envCfg.TaskBrokerServerURI, envCfg.AuthToken)
+		runnerGrantToken, err := http.FetchGrantToken(envCfg.TaskBrokerServerURI, envCfg.AuthToken)
 		if err != nil {
 			return fmt.Errorf("failed to fetch grant token for runner: %w", err)
 		}

--- a/internal/http/check_until_n8n_ready.go
+++ b/internal/http/check_until_n8n_ready.go
@@ -23,10 +23,10 @@ func sendReadinessRequest(n8nMainServerURI string) (*http.Response, error) {
 	return client.Do(req)
 }
 
-// WaitForN8nReady checks forever until the n8n main instance is ready, i.e.
+// CheckUntilN8nReady checks forever until the n8n main instance is ready, i.e.
 // until its DB is connected and migrated. In case of long-running migrations,
 // readiness may take a long time. Returns nil when ready.
-func WaitForN8nReady(n8nMainServerURI string) error {
+func CheckUntilN8nReady(n8nMainServerURI string) error {
 	logs.Info("Waiting for n8n to be ready...")
 
 	readinessCheck := func() (string, error) {

--- a/internal/http/fetch_grant_token.go
+++ b/internal/http/fetch_grant_token.go
@@ -1,4 +1,4 @@
-package auth
+package http
 
 import (
 	"bytes"

--- a/internal/ws/handshake.go
+++ b/internal/ws/handshake.go
@@ -1,4 +1,4 @@
-package auth
+package ws
 
 import (
 	"crypto/rand"


### PR DESCRIPTION
This PR organizes files in the `internal` dir for consistency, as setup for adding more tests:

- Move `auth/token_exchange.go` to `http/fetch_grant_token.go`
- Move `auth/handshake.go` to `ws/handshake.go`
- Made `commands/command.go` part of `commands/launch.go`
- Rename `http/wait_for_n8n.go` to `http/check_until_n8n_ready.go`