### PR TITLE
test: Ensure consistent order in `AllowedOnly` result

### DIFF
--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -79,6 +80,8 @@ func AllowedOnly(allowed []string) []string {
 			}
 		}
 	}
+
+	sort.Strings(filtered) // ensure consistent order
 
 	return filtered
 }


### PR DESCRIPTION
Go maps do not guarantee iteration order, which can occassionally break tests for `AllowedOnly`

```
Run go test -coverprofile=coverage.out ./...
 task-runner-launcher/cmd/launcher coverage: 0.0% of statements
? task-runner-launcher/internal/errs [no test files]
 task-runner-launcher/internal/commands coverage: 0.0% of statements
 task-runner-launcher/internal/http coverage: 0.0% of statements
 task-runner-launcher/internal/config coverage: 0.0% of statements
--- FAIL: TestAllowedOnly (0.00s)
 --- FAIL: TestAllowedOnly/returns_only_allowed_env_vars (0.00s)
 env_test.go:64: AllowedOnly() = [ALLOWED2=value2 ALLOWED1=value1], want [ALLOWED1=value1 ALLOWED2=value2]
FAIL
coverage: 98.2% of statements
FAIL task-runner-launcher/internal/env 0.004s
 task-runner-launcher/internal/logs coverage: 0.0% of statements
 task-runner-launcher/internal/ws coverage: 0.0% of statements
 task-runner-launcher/internal/retry coverage: 0.0% of statements
FAIL
```
