### PR TITLE
refactor: Simplify configuration

### DIFF
--- a/internal/commands/launch.go
+++ b/internal/commands/launch.go
@@ -70,9 +70,11 @@ func (l *LaunchCommand) Execute() error {
 
 	// 3. filter environment variables
 
-	defaultEnvs := []string{"LANG", "PATH", "TZ", "TERM", env.EnvVarIdleTimeout, env.EnvVarRunnerServerEnabled}
+	defaultEnvs := []string{"LANG", "PATH", "TZ", "TERM", env.EnvVarIdleTimeout}
 	allowedEnvs := append(defaultEnvs, runnerCfg.AllowedEnv...)
 	runnerEnv := env.AllowedOnly(allowedEnvs)
+	// Static values
+	runnerEnv = append(runnerEnv, "N8N_RUNNERS_SERVER_ENABLED=true")
 
 	logs.Debugf("Filtered environment variables")
 
@@ -140,7 +142,7 @@ func (l *LaunchCommand) Execute() error {
 			return fmt.Errorf("failed to start runner process: %w", err)
 		}
 
-		go http.MonitorRunnerHealth(ctx, cmd, envCfg.RunnerServerURI, &wg)
+		go http.MonitorRunnerHealth(ctx, cmd, env.RunnerServerURI, &wg)
 
 		err = cmd.Wait()
 		if err != nil && err.Error() == "signal: killed" {

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -40,14 +40,6 @@ const (
 	//         runner
 	// ------------------------
 
-	// EnvVarRunnerServerURI is the env var for the URI of the runner's server.
-	// Used for monitoring the runner's health, typically at http://127.0.0.1:5681.
-	EnvVarRunnerServerURI = "N8N_RUNNER_URI"
-
-	// EnvVarRunnerServerEnabled is the env var for whether the runner's health
-	// check server should be started.
-	EnvVarRunnerServerEnabled = "N8N_RUNNERS_SERVER_ENABLED"
-
 	// EnvVarIdleTimeout is the env var for how long (in seconds) a runner may be
 	// idle for before exit.
 	EnvVarIdleTimeout = "N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT"
@@ -57,7 +49,9 @@ const (
 	defaultIdleTimeoutValue    = "15" // seconds
 	DefaultMainServerURI       = "http://127.0.0.1:5678"
 	DefaultTaskBrokerServerURI = "http://127.0.0.1:5679"
-	DefaultRunnerServerURI     = "http://127.0.0.1:5681"
+
+	// URI of the runner. Used for monitoring the runner's health
+	RunnerServerURI = "http://127.0.0.1:5681"
 )
 
 // AllowedOnly filters the current environment down to only those
@@ -127,7 +121,6 @@ type EnvConfig struct {
 	AuthToken           string
 	MainServerURI       string
 	TaskBrokerServerURI string
-	RunnerServerURI     string
 }
 
 // FromEnv retrieves vars from the environment, validates their values, and
@@ -138,7 +131,6 @@ func FromEnv() (*EnvConfig, error) {
 	authToken := os.Getenv(EnvVarAuthToken)
 	mainServerURI := os.Getenv(EnvVarMainServerURI)
 	taskBrokerServerURI := os.Getenv(EnvVarTaskBrokerServerURI)
-	runnerServerURI := os.Getenv(EnvVarRunnerServerURI)
 	idleTimeout := os.Getenv(EnvVarIdleTimeout)
 
 	if authToken == "" {
@@ -148,12 +140,6 @@ func FromEnv() (*EnvConfig, error) {
 	if mainServerURI == "" {
 		mainServerURI = DefaultMainServerURI
 	} else if err := validateURL(mainServerURI, EnvVarMainServerURI); err != nil {
-		errs = append(errs, err)
-	}
-
-	if runnerServerURI == "" {
-		runnerServerURI = DefaultRunnerServerURI
-	} else if err := validateURL(runnerServerURI, EnvVarRunnerServerURI); err != nil {
 		errs = append(errs, err)
 	}
 
@@ -176,12 +162,9 @@ func FromEnv() (*EnvConfig, error) {
 		return nil, errors.Join(errs...)
 	}
 
-	os.Setenv(EnvVarRunnerServerEnabled, "true")
-
 	return &EnvConfig{
 		AuthToken:           authToken,
 		MainServerURI:       mainServerURI,
 		TaskBrokerServerURI: taskBrokerServerURI,
-		RunnerServerURI:     runnerServerURI,
 	}, nil
 }

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -156,14 +156,12 @@ func TestFromEnv(t *testing.T) {
 				EnvVarAuthToken:           "token123",
 				EnvVarMainServerURI:       "http://localhost:9000",
 				EnvVarTaskBrokerServerURI: "http://localhost:9001",
-				EnvVarRunnerServerURI:     "http://localhost:9002",
 				EnvVarIdleTimeout:         "30",
 			},
 			expected: &EnvConfig{
 				AuthToken:           "token123",
 				MainServerURI:       "http://localhost:9000",
 				TaskBrokerServerURI: "http://localhost:9001",
-				RunnerServerURI:     "http://localhost:9002",
 			},
 		},
 		{
@@ -171,7 +169,6 @@ func TestFromEnv(t *testing.T) {
 			envVars: map[string]string{
 				EnvVarMainServerURI:       "http://localhost:5678",
 				EnvVarTaskBrokerServerURI: "http://localhost:5679",
-				EnvVarRunnerServerURI:     "http://localhost:5681",
 			},
 			expectError: true,
 		},
@@ -181,7 +178,6 @@ func TestFromEnv(t *testing.T) {
 				EnvVarAuthToken:           "token123",
 				EnvVarMainServerURI:       "http://\\invalid:5678",
 				EnvVarTaskBrokerServerURI: "http://localhost:5679",
-				EnvVarRunnerServerURI:     "http://localhost:5681",
 			},
 			expectError: true,
 		},
@@ -190,13 +186,11 @@ func TestFromEnv(t *testing.T) {
 			envVars: map[string]string{
 				EnvVarAuthToken:           "token123",
 				EnvVarTaskBrokerServerURI: "http://localhost:5679",
-				EnvVarRunnerServerURI:     "http://localhost:5681",
 			},
 			expected: &EnvConfig{
 				AuthToken:           "token123",
 				MainServerURI:       DefaultMainServerURI,
 				TaskBrokerServerURI: "http://localhost:5679",
-				RunnerServerURI:     "http://localhost:5681",
 			},
 		},
 		{
@@ -205,46 +199,19 @@ func TestFromEnv(t *testing.T) {
 				EnvVarAuthToken:           "token123",
 				EnvVarMainServerURI:       "http://localhost:5678",
 				EnvVarTaskBrokerServerURI: "http://\\invalid:5679",
-				EnvVarRunnerServerURI:     "http://localhost:5681",
 			},
 			expectError: true,
 		},
 		{
 			name: "missing task broker server URI",
 			envVars: map[string]string{
-				EnvVarAuthToken:       "token123",
-				EnvVarMainServerURI:   "http://localhost:5678",
-				EnvVarRunnerServerURI: "http://localhost:5681",
+				EnvVarAuthToken:     "token123",
+				EnvVarMainServerURI: "http://localhost:5678",
 			},
 			expected: &EnvConfig{
 				AuthToken:           "token123",
 				MainServerURI:       "http://localhost:5678",
 				TaskBrokerServerURI: DefaultTaskBrokerServerURI,
-				RunnerServerURI:     "http://localhost:5681",
-			},
-		},
-		{
-			name: "invalid runner server URI",
-			envVars: map[string]string{
-				EnvVarAuthToken:           "token123",
-				EnvVarMainServerURI:       "http://localhost:5678",
-				EnvVarTaskBrokerServerURI: "http://localhost:5679",
-				EnvVarRunnerServerURI:     "http://\\invalid:5681",
-			},
-			expectError: true,
-		},
-		{
-			name: "missing runner server URI",
-			envVars: map[string]string{
-				EnvVarAuthToken:           "token123",
-				EnvVarMainServerURI:       "http://localhost:5678",
-				EnvVarTaskBrokerServerURI: "http://localhost:5679",
-			},
-			expected: &EnvConfig{
-				AuthToken:           "token123",
-				MainServerURI:       "http://localhost:5678",
-				TaskBrokerServerURI: "http://localhost:5679",
-				RunnerServerURI:     DefaultRunnerServerURI,
 			},
 		},
 		{
@@ -253,7 +220,6 @@ func TestFromEnv(t *testing.T) {
 				EnvVarAuthToken:           "token123",
 				EnvVarMainServerURI:       "127.0.0.1:5678",
 				EnvVarTaskBrokerServerURI: "http://localhost:5679",
-				EnvVarRunnerServerURI:     "http://localhost:5681",
 			},
 			expectError: true,
 		},
@@ -263,7 +229,6 @@ func TestFromEnv(t *testing.T) {
 				EnvVarAuthToken:           "token123",
 				EnvVarMainServerURI:       "localhost:5678",
 				EnvVarTaskBrokerServerURI: "http://localhost:5679",
-				EnvVarRunnerServerURI:     "http://localhost:5681",
 			},
 			expectError: true,
 		},
@@ -273,7 +238,6 @@ func TestFromEnv(t *testing.T) {
 				EnvVarAuthToken:           "token123",
 				EnvVarMainServerURI:       "http://localhost:5678",
 				EnvVarTaskBrokerServerURI: "http://localhost:5679",
-				EnvVarRunnerServerURI:     "http://localhost:5681",
 				EnvVarIdleTimeout:         "invalid",
 			},
 			expectError: true,
@@ -284,7 +248,6 @@ func TestFromEnv(t *testing.T) {
 				EnvVarAuthToken:           "token123",
 				EnvVarMainServerURI:       "http://localhost:5678",
 				EnvVarTaskBrokerServerURI: "http://localhost:5679",
-				EnvVarRunnerServerURI:     "http://localhost:5681",
 				EnvVarIdleTimeout:         "-1",
 			},
 			expectError: true,
@@ -319,10 +282,6 @@ func TestFromEnv(t *testing.T) {
 
 			if !reflect.DeepEqual(envCfg, tt.expected) {
 				t.Errorf("FromEnv() = %+v, want %+v", envCfg, tt.expected)
-			}
-
-			if os.Getenv(EnvVarRunnerServerEnabled) != "true" {
-				t.Error("FromEnv() did not set runner server enabled to true")
 			}
 		})
 	}


### PR DESCRIPTION
Remove`N8N_RUNNER_URI` and `N8N_RUNNERS_SERVER_ENABLED` env vars. These can be statically. For the launcher to be able to monitor the runner, the `N8N_RUNNERS_SERVER_ENABLED` env var needs to be set to `true`. Hence there's not reason to let it be configurable. Same applies for `N8N_RUNNER_URI`, which we know is going to be localhost, since the launcher starts the runner.