### PR TITLE
refactor: Unify task runner env vars

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -38,4 +38,4 @@ make run
 ```
 
 > [!TIP]
-> You can use `N8N_LAUNCHER_LOG_LEVEL=debug` for granular logging and `NO_COLOR=1` to disable color output.
+> You can use `N8N_RUNNERS_LAUNCHER_LOG_LEVEL=debug` for granular logging and `NO_COLOR=1` to disable color output.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -44,13 +44,13 @@ Task runner config fields:
 
 - It is required to specify an auth token by setting `N8N_RUNNERS_AUTH_TOKEN` to a secret. The launcher will use this secret to authenticate with the n8n instance. You will also pass this `N8N_RUNNERS_AUTH_TOKEN` to the n8n instance as well.
 
-- Optionally, specify the launcher's log level by setting `N8N_LAUNCHER_LOG_LEVEL` to `debug`, `info`, `warn` or `error`. Default is `info`. You can also use `NO_COLOR=1` to disable color output.
+- Optionally, specify the launcher's log level by setting `N8N_RUNNERS_LAUNCHER_LOG_LEVEL` to `debug`, `info`, `warn` or `error`. Default is `info`. You can also use `NO_COLOR=1` to disable color output.
 
 - Optionally, specify the launcher's auto-shutdown timeout by setting `N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT` to a number of seconds, or set it to `0` to disable. Default is `15`. The runner will exit after this timeout if it is idle for the specified duration, and will be re-launched on demand when the next task comes in.
 
 - Optionally, specify the task broker's URI (i.e. n8n instance's URI) by setting `N8N_RUNNERS_TASK_BROKER_URI`. Default is `http://127.0.0.1:5679`.
 
-- Optionally, specify the port for the launcher's health check server by setting `N8N_LAUNCHER_HEALTH_CHECK_PORT`. Default is `5680`. When overriding this port, be mindful of port conflicts - by default, the n8n instance uses `5678` for its regular server and `5679` for its task broker server, and the runner uses `5681` for its healthcheck server.
+- Optionally, specify the port for the launcher's health check server by setting `N8N_RUNNERS_LAUNCHER_HEALTH_CHECK_PORT`. Default is `5680`. When overriding this port, be mindful of port conflicts - by default, the n8n instance uses `5678` for its regular server and `5679` for its task broker server, and the runner uses `5681` for its healthcheck server.
 
 - Optionally, configure [Sentry error tracking](https://docs.sentry.io/platforms/go/configuration/options/) with these env vars:
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -20,7 +20,7 @@ This launcher is intended for deployment as a sidecar container alongside one or
         "PATH",
         "GENERIC_TIMEZONE",
         "N8N_RUNNERS_GRANT_TOKEN",
-        "N8N_RUNNERS_N8N_URI",
+        "N8N_RUNNERS_TASK_BROKER_URI",
         "N8N_RUNNERS_MAX_PAYLOAD",
         "N8N_RUNNERS_MAX_CONCURRENCY",
         "NODE_FUNCTION_ALLOW_BUILTIN",
@@ -48,7 +48,7 @@ Task runner config fields:
 
 - Optionally, specify the launcher's auto-shutdown timeout by setting `N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT` to a number of seconds, or set it to `0` to disable. Default is `15`. The runner will exit after this timeout if it is idle for the specified duration, and will be re-launched on demand when the next task comes in.
 
-- Optionally, specify the task broker's URI (i.e. n8n instance's URI) by setting `N8N_TASK_BROKER_URI`. Default is `http://127.0.0.1:5679`.
+- Optionally, specify the task broker's URI (i.e. n8n instance's URI) by setting `N8N_RUNNERS_TASK_BROKER_URI`. Default is `http://127.0.0.1:5679`.
 
 - Optionally, specify the port for the launcher's health check server by setting `N8N_LAUNCHER_HEALTH_CHECK_PORT`. Default is `5680`. When overriding this port, be mindful of port conflicts - by default, the n8n instance uses `5678` for its regular server and `5679` for its task broker server, and the runner uses `5681` for its healthcheck server.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,7 +36,7 @@ type Config struct {
 	AutoShutdownTimeout string `env:"N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT, default=15"`
 
 	// TaskBrokerURI is the URI of the task broker server.
-	TaskBrokerURI string `env:"N8N_TASK_BROKER_URI, default=http://127.0.0.1:5679"`
+	TaskBrokerURI string `env:"N8N_RUNNERS_TASK_BROKER_URI, default=http://127.0.0.1:5679"`
 
 	// HealthCheckServerPort is the port for the launcher's health check server.
 	HealthCheckServerPort string `env:"N8N_LAUNCHER_HEALTH_CHECK_PORT, default=5680"`
@@ -89,7 +89,7 @@ func LoadConfig(runnerType string, lookuper envconfig.Lookuper) (*Config, error)
 
 	// launcher
 
-	if err := validateURL(cfg.TaskBrokerURI, "N8N_TASK_BROKER_URI"); err != nil {
+	if err := validateURL(cfg.TaskBrokerURI, "N8N_RUNNERS_TASK_BROKER_URI"); err != nil {
 		cfgErrs = append(cfgErrs, err)
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,13 +19,13 @@ var cfg Config
 
 const (
 	// EnvVarHealthCheckPort is the env var for the port for the launcher's health check server.
-	EnvVarHealthCheckPort = "N8N_LAUNCHER_HEALTH_CHECK_PORT"
+	EnvVarHealthCheckPort = "N8N_RUNNERS_LAUNCHER_HEALTH_CHECK_PORT"
 )
 
 // Config holds the full configuration for the launcher.
 type Config struct {
 	// LogLevel is the log level for the launcher. Default: `info`.
-	LogLevel string `env:"N8N_LAUNCHER_LOG_LEVEL, default=info"`
+	LogLevel string `env:"N8N_RUNNERS_LAUNCHER_LOG_LEVEL, default=info"`
 
 	// AuthToken is the auth token sent by the launcher to the task broker in
 	// exchange for a single-use grant token, later passed to the runner.
@@ -39,7 +39,7 @@ type Config struct {
 	TaskBrokerURI string `env:"N8N_RUNNERS_TASK_BROKER_URI, default=http://127.0.0.1:5679"`
 
 	// HealthCheckServerPort is the port for the launcher's health check server.
-	HealthCheckServerPort string `env:"N8N_LAUNCHER_HEALTH_CHECK_PORT, default=5680"`
+	HealthCheckServerPort string `env:"N8N_RUNNERS_LAUNCHER_HEALTH_CHECK_PORT, default=5680"`
 
 	// Runner is the runner config for the task runner, obtained from:
 	// `/etc/n8n-task-runners.json`.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -35,9 +35,9 @@ func TestLoadConfig(t *testing.T) {
 			name:          "valid configuration",
 			configContent: validConfigContent,
 			envVars: map[string]string{
-				"N8N_RUNNERS_AUTH_TOKEN": "test-token",
-				"N8N_TASK_BROKER_URI":    "http://localhost:5679",
-				"SENTRY_DSN":             "https://test@sentry.io/123",
+				"N8N_RUNNERS_AUTH_TOKEN":      "test-token",
+				"N8N_RUNNERS_TASK_BROKER_URI": "http://localhost:5679",
+				"SENTRY_DSN":                  "https://test@sentry.io/123",
 			},
 			runnerType:    "javascript",
 			expectedError: false,
@@ -46,9 +46,9 @@ func TestLoadConfig(t *testing.T) {
 			name:          "valid configuration",
 			configContent: validConfigContent,
 			envVars: map[string]string{
-				"N8N_RUNNERS_AUTH_TOKEN": "test-token",
-				"N8N_TASK_BROKER_URI":    "http://127.0.0.1:5679",
-				"SENTRY_DSN":             "https://test@sentry.io/123",
+				"N8N_RUNNERS_AUTH_TOKEN":      "test-token",
+				"N8N_RUNNERS_TASK_BROKER_URI": "http://127.0.0.1:5679",
+				"SENTRY_DSN":                  "https://test@sentry.io/123",
 			},
 			runnerType:    "javascript",
 			expectedError: false,
@@ -92,8 +92,8 @@ func TestConfigFileErrors(t *testing.T) {
 			configContent: "invalid json",
 			expectedError: "failed to parse config file",
 			envVars: map[string]string{
-				"N8N_RUNNERS_AUTH_TOKEN": "test-token",
-				"N8N_TASK_BROKER_URI":    "http://localhost:5679",
+				"N8N_RUNNERS_AUTH_TOKEN":      "test-token",
+				"N8N_RUNNERS_TASK_BROKER_URI": "http://localhost:5679",
 			},
 		},
 		{
@@ -103,8 +103,8 @@ func TestConfigFileErrors(t *testing.T) {
 			}`,
 			expectedError: "found no task runner configs",
 			envVars: map[string]string{
-				"N8N_RUNNERS_AUTH_TOKEN": "test-token",
-				"N8N_TASK_BROKER_URI":    "http://localhost:5679",
+				"N8N_RUNNERS_AUTH_TOKEN":      "test-token",
+				"N8N_RUNNERS_TASK_BROKER_URI": "http://localhost:5679",
 			},
 		},
 		{
@@ -120,8 +120,8 @@ func TestConfigFileErrors(t *testing.T) {
 			}`,
 			expectedError: "does not contain requested runner type: javascript",
 			envVars: map[string]string{
-				"N8N_RUNNERS_AUTH_TOKEN": "test-token",
-				"N8N_TASK_BROKER_URI":    "http://localhost:5679",
+				"N8N_RUNNERS_AUTH_TOKEN":      "test-token",
+				"N8N_RUNNERS_TASK_BROKER_URI": "http://localhost:5679",
 			},
 		},
 	}

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -78,7 +78,7 @@ func PrepareRunnerEnv(cfg *config.Config) []string {
 	allowedEnvs := append(defaultEnvs, cfg.Runner.AllowedEnv...)
 
 	runnerEnv := allowedOnly(allowedEnvs)
-	runnerEnv = append(runnerEnv, "N8N_RUNNERS_SERVER_ENABLED=true")
+	runnerEnv = append(runnerEnv, "N8N_RUNNERS_HEALTH_CHECK_SERVER_ENABLED=true")
 	runnerEnv = append(runnerEnv, fmt.Sprintf("%s=%s", EnvVarAutoShutdownTimeout, cfg.AutoShutdownTimeout))
 
 	return runnerEnv

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -176,7 +176,7 @@ func TestPrepareRunnerEnv(t *testing.T) {
 				"CUSTOM_VAR2=value2",
 				"LANG=en_US.UTF-8",
 				"N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT=15",
-				"N8N_RUNNERS_SERVER_ENABLED=true",
+				"N8N_RUNNERS_HEALTH_CHECK_SERVER_ENABLED=true",
 				"PATH=/usr/bin",
 				"TERM=xterm",
 				"TZ=UTC",
@@ -198,7 +198,7 @@ func TestPrepareRunnerEnv(t *testing.T) {
 			expected: []string{
 				"LANG=en_US.UTF-8",
 				"N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT=15",
-				"N8N_RUNNERS_SERVER_ENABLED=true",
+				"N8N_RUNNERS_HEALTH_CHECK_SERVER_ENABLED=true",
 				"PATH=/usr/bin",
 			},
 		},
@@ -216,7 +216,7 @@ func TestPrepareRunnerEnv(t *testing.T) {
 			},
 			expected: []string{
 				"N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT=30",
-				"N8N_RUNNERS_SERVER_ENABLED=true",
+				"N8N_RUNNERS_HEALTH_CHECK_SERVER_ENABLED=true",
 				"PATH=/usr/bin",
 			},
 		},


### PR DESCRIPTION
- Rename `N8N_TASK_BROKER_URI` to `N8N_RUNNERS_TASK_BROKER_URI`
- Rename `N8N_RUNNERS_SERVER_ENABLED` to `N8N_RUNNERS_HEALTH_CHECK_SERVER_ENABLED`
- Rename `N8N_LAUNCHER_HEALTH_CHECK_PORT` to `N8N_RUNNERS_LAUNCHER_HEALTH_CHECK_PORT`
- Rename `N8N_LAUNCHER_LOG_LEVEL` to `N8N_RUNNERS_LAUNCHER_LOG_LEVEL`

Related PR: https://github.com/n8n-io/n8n/pull/12040