### PR TITLE
refactor: Reduce log verboseness

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ CLI utility to launch an [n8n task runner](https://docs.n8n.io/PENDING) in `exte
 2024/11/29 13:37:46 DEBUG Changed into working directory
 2024/11/29 13:37:46 DEBUG Prepared env vars for runner
 2024/11/29 13:37:46 INFO  Waiting for task broker to be ready...
-2024/11/29 13:37:46 INFO  Task broker is ready
+2024/11/29 13:37:46 DEBUG Task broker is ready
 2024/11/29 13:37:46 DEBUG Fetched grant token for launcher
-2024/11/29 13:37:46 INFO  Launcher's runner ID: fc6c24b9f764ae55
+2024/11/29 13:37:46 DEBUG Launcher's runner ID: fc6c24b9f764ae55
 2024/11/29 13:37:46 DEBUG Connected: ws://127.0.0.1:5679/runners/_ws?id=fc6c24b9f764ae55
 2024/11/29 13:37:46 DEBUG <- Received message `broker:inforequest`
 2024/11/29 13:37:46 DEBUG -> Sent message `runner:info`

--- a/internal/http/check_until_broker_ready.go
+++ b/internal/http/check_until_broker_ready.go
@@ -47,7 +47,7 @@ func CheckUntilBrokerReady(taskBrokerURI string) error {
 		return err
 	}
 
-	logs.Info("Task broker is ready")
+	logs.Debug("Task broker is ready")
 
 	return nil
 }

--- a/internal/ws/handshake.go
+++ b/internal/ws/handshake.go
@@ -113,7 +113,7 @@ func Handshake(cfg HandshakeConfig) error {
 	}
 
 	runnerID := randomID()
-	logs.Infof("Launcher's runner ID: %s", runnerID)
+	logs.Debugf("Launcher's runner ID: %s", runnerID)
 
 	wsURL, err := buildWebsocketURL(cfg.TaskBrokerServerURI, runnerID)
 	if err != nil {
@@ -207,7 +207,7 @@ func Handshake(cfg HandshakeConfig) error {
 		wsConn.Close()
 		return err
 	case <-handshakeComplete:
-		logs.Info("Runner's task offer was accepted")
+		logs.Debug("Runner's task offer was accepted")
 		return nil
 	}
 }


### PR DESCRIPTION
Move the following logs to debug level:
- `Task broker is ready`
- `Launcher's runner ID: f9f15e9381262fbb`
- `Runner's task offer was accepted`

With info level, the following logs are printed:

```
2024/12/12 17:03:58 INFO  Starting launcher...
2024/12/12 17:03:58 INFO  Starting launcher's health check server at port 5680
2024/12/12 17:03:58 INFO  Waiting for task broker to be ready...
2024/12/12 17:05:03 INFO  Waiting for launcher's task offer to be accepted...
2024/12/12 17:05:15 DEBUG [Runner] Health check server listening on 127.0.0.1, port 5681
2024/12/12 17:05:30 DEBUG [Runner] Received IDLE_TIMEOUT signal, shutting down...
2024/12/12 17:05:30 DEBUG [Runner] Task runner stopped
2024/12/12 17:05:30 INFO  Runner exited on idle timeout
2024/12/12 17:05:30 INFO  Waiting for task broker to be ready...
2024/12/12 17:05:30 INFO  Waiting for launcher's task offer to be accepted...
```