### PR TITLE
feat: Add `env-overrides` and protect required runtime variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@ CLI utility to launch an [n8n task runner](https://docs.n8n.io/hosting/configura
 - [Development](docs/development.md) - how to set up a development environment to work on the launcher
 - [Release](docs/release.md) - how to release a new version of the launcher
 - [Lifecycle](docs/lifecycle.md) - how the launcher works
+- [Environment](docs/environment.md) - how the launcher handles environment variables

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -1,0 +1,35 @@
+# Environment
+
+The launcher passes two kinds of environment variables to task runners:
+
+- Env vars from the launcher's own environment, if allowed by `allowed-env` in `n8n-task-runners.json`.
+- Env vars set by the launcher directly on the runner, as specified in `env-overrides` in `n8n-task-runners.json`. This is useful for setting different env vars on separate runner types. On conflict, env vars in `env-overrides` take precedence over env vars in `allowed-env`.
+
+Example:
+
+```json
+{
+  "task-runners": [
+    {
+      "allowed-env": [
+        "PATH",
+        "GENERIC_TIMEZONE",
+        "N8N_RUNNERS_MAX_PAYLOAD",
+        "N8N_RUNNERS_MAX_CONCURRENCY",
+        "N8N_RUNNERS_TASK_TIMEOUT",
+      ],
+      "override-envs": [
+        "NODE_FUNCTION_ALLOW_BUILTIN=crypto",
+        "NODE_FUNCTION_ALLOW_EXTERNAL=moment"
+        "NODE_OPTIONS=--max-old-space-size=4096"
+      ]
+    },
+  ]
+}
+```
+
+Exceptionally, these three env vars cannot be disallowed or overriden:
+
+- `N8N_RUNNERS_TASK_BROKER_URI`
+- `N8N_RUNNERS_GRANT_TOKEN`
+- `N8N_RUNNERS_HEALTH_CHECK_SERVER_ENABLED=true`

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -19,16 +19,16 @@ This launcher is intended for deployment as a sidecar container alongside one or
       "allowed-env": [
         "PATH",
         "GENERIC_TIMEZONE",
-        "N8N_RUNNERS_GRANT_TOKEN",
-        "N8N_RUNNERS_TASK_BROKER_URI",
-        "N8N_RUNNERS_MAX_PAYLOAD",
-        "N8N_RUNNERS_MAX_CONCURRENCY",
-        "N8N_RUNNERS_TASK_TIMEOUT",
-        "NODE_FUNCTION_ALLOW_BUILTIN",
-        "NODE_FUNCTION_ALLOW_EXTERNAL",
-        "NODE_OPTIONS"
+      ],
+      "override-envs": [
+        "N8N_RUNNERS_TASK_TIMEOUT=80",
+        "N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT=120",
+        "N8N_RUNNERS_MAX_CONCURRENCY=3",
+        "NODE_FUNCTION_ALLOW_BUILTIN=crypto",
+        "NODE_FUNCTION_ALLOW_EXTERNAL=moment"
+        "NODE_OPTIONS=--max-old-space-size=4096",
       ]
-    }
+    },
   ]
 }
 ```
@@ -39,7 +39,7 @@ Task runner config fields:
 - `workdir` is the path to directory containing the task runner binary.
 - `command` is the command to execute in order to start the task runner.
 - `args` are the args for the command to execute, currently the path to the task runner entrypoint.
-- `allowed-env` are the env vars that the launcher is allowed to pass to the task runner.
+- `allowed-env` and `override-envs` are env vars that the launcher will pass through to or set directly on the runner, respectively. See [environment](environment.md).
 
 3. Set the **environment variables** for the launcher.
 
@@ -54,7 +54,6 @@ Task runner config fields:
 - Optionally, specify the port for the launcher's health check server by setting `N8N_RUNNERS_LAUNCHER_HEALTH_CHECK_PORT`. Default is `5680`. When overriding this port, be mindful of port conflicts - by default, the n8n instance uses `5678` for its regular server and `5679` for its task broker server, and the runner uses `5681` for its health check server.
 
 - Optionally, configure [Sentry error tracking](https://docs.sentry.io/platforms/go/configuration/options/) with these env vars:
-
   - `SENTRY_DSN`
   - `DEPLOYMENT_NAME`: Mapped to `ServerName`
   - `ENVIRONMENT`: Mapped to `Environment`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,8 +75,11 @@ type RunnerConfig struct {
 	// Arguments for command, currently path to runner entrypoint.
 	Args []string `json:"args"`
 
-	// Env vars allowed to be passed by launcher to runner.
+	// Env vars for the launcher to pass from its own environment to the runner.
 	AllowedEnv []string `json:"allowed-env"`
+
+	// Env vars for the launcher to set directly on the runner.
+	EnvOverrides []string `json:"env-overrides"`
 }
 
 func LoadConfig(runnerType string, lookuper envconfig.Lookuper) (*Config, error) {

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -89,7 +89,6 @@ func Clear(envVars []string, envVarName string) []string {
 	return result
 }
 
-// Check for users who will be affected by the breaking change
 func checkLegacyBehavior(cfg *config.Config) {
 	timeoutEnvVars := []string{
 		EnvVarAutoShutdownTimeout,

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -173,6 +173,7 @@ func TestPrepareRunnerEnv(t *testing.T) {
 			config: &config.Config{
 				AutoShutdownTimeout: "15",
 				TaskTimeout:         "60",
+				TaskBrokerURI:       "http://localhost:5679",
 				Runner: &config.RunnerConfig{
 					AllowedEnv: []string{"CUSTOM_VAR1", "CUSTOM_VAR2"},
 				},
@@ -192,6 +193,7 @@ func TestPrepareRunnerEnv(t *testing.T) {
 				"LANG=en_US.UTF-8",
 				"N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT=15",
 				"N8N_RUNNERS_HEALTH_CHECK_SERVER_ENABLED=true",
+				"N8N_RUNNERS_TASK_BROKER_URI=http://localhost:5679",
 				"N8N_RUNNERS_TASK_TIMEOUT=60",
 				"PATH=/usr/bin",
 				"TERM=xterm",
@@ -203,6 +205,7 @@ func TestPrepareRunnerEnv(t *testing.T) {
 			config: &config.Config{
 				AutoShutdownTimeout: "15",
 				TaskTimeout:         "60",
+				TaskBrokerURI:       "http://localhost:5679",
 				Runner: &config.RunnerConfig{
 					AllowedEnv: []string{},
 				},
@@ -216,6 +219,7 @@ func TestPrepareRunnerEnv(t *testing.T) {
 				"LANG=en_US.UTF-8",
 				"N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT=15",
 				"N8N_RUNNERS_HEALTH_CHECK_SERVER_ENABLED=true",
+				"N8N_RUNNERS_TASK_BROKER_URI=http://localhost:5679",
 				"N8N_RUNNERS_TASK_TIMEOUT=60",
 				"PATH=/usr/bin",
 			},
@@ -225,6 +229,7 @@ func TestPrepareRunnerEnv(t *testing.T) {
 			config: &config.Config{
 				AutoShutdownTimeout: "30",
 				TaskTimeout:         "60",
+				TaskBrokerURI:       "http://localhost:5679",
 				Runner: &config.RunnerConfig{
 					AllowedEnv: []string{},
 				},
@@ -236,6 +241,65 @@ func TestPrepareRunnerEnv(t *testing.T) {
 			expected: []string{
 				"N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT=30",
 				"N8N_RUNNERS_HEALTH_CHECK_SERVER_ENABLED=true",
+				"N8N_RUNNERS_TASK_BROKER_URI=http://localhost:5679",
+				"N8N_RUNNERS_TASK_TIMEOUT=60",
+				"PATH=/usr/bin",
+			},
+		},
+		{
+			name: "handles env-overrides",
+			config: &config.Config{
+				TaskBrokerURI:       "http://localhost:5679",
+				AutoShutdownTimeout: "30",
+				TaskTimeout:         "60",
+				Runner: &config.RunnerConfig{
+					AllowedEnv:   []string{"CUSTOM_VAR1", "CUSTOM_VAR2"},
+					EnvOverrides: []string{"CUSTOM_VAR1=overridden", "NEW_VAR=added"},
+				},
+			},
+			envSetup: map[string]string{
+				"PATH":        "/usr/bin",
+				"LANG":        "en_US.UTF-8",
+				"CUSTOM_VAR1": "original",
+				"CUSTOM_VAR2": "value2",
+			},
+			expected: []string{
+				"CUSTOM_VAR1=overridden",
+				"CUSTOM_VAR2=value2",
+				"LANG=en_US.UTF-8",
+				"N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT=30",
+				"N8N_RUNNERS_HEALTH_CHECK_SERVER_ENABLED=true",
+				"N8N_RUNNERS_TASK_BROKER_URI=http://localhost:5679",
+				"N8N_RUNNERS_TASK_TIMEOUT=60",
+				"NEW_VAR=added",
+				"PATH=/usr/bin",
+			},
+		},
+		{
+			name: "disregards env-overrides for required runtime variables",
+			config: &config.Config{
+				TaskBrokerURI:       "http://localhost:5679",
+				AutoShutdownTimeout: "30",
+				TaskTimeout:         "60",
+				Runner: &config.RunnerConfig{
+					AllowedEnv: []string{},
+					EnvOverrides: []string{
+						"N8N_RUNNERS_TASK_BROKER_URI=http://evil:5679",
+						"N8N_RUNNERS_HEALTH_CHECK_SERVER_ENABLED=false",
+						"CUSTOM_VAR=allowed",
+					},
+				},
+			},
+			envSetup: map[string]string{
+				"PATH": "/usr/bin",
+				"LANG": "en_US.UTF-8",
+			},
+			expected: []string{
+				"CUSTOM_VAR=allowed",
+				"LANG=en_US.UTF-8",
+				"N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT=30",
+				"N8N_RUNNERS_HEALTH_CHECK_SERVER_ENABLED=true",
+				"N8N_RUNNERS_TASK_BROKER_URI=http://localhost:5679",
 				"N8N_RUNNERS_TASK_TIMEOUT=60",
 				"PATH=/usr/bin",
 			},


### PR DESCRIPTION
- Introduce `env-overrides` to the runner config. This enables users to define different env vars per runner type.
- Prevent the user from disallowing or overriding the three required runtime env vars: `N8N_RUNNERS_TASK_BROKER_URI`, `N8N_RUNNERS_GRANT_TOKEN`, and `N8N_RUNNERS_HEALTH_CHECK_SERVER_ENABLED`.
- Add deprecation notice. The launcher should not be hardcoding `N8N_RUNNERS_TASK_TIMEOUT` and `N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT` as passthrough env vars. If the user needs the launcher to pass these through, then they should include them in `allowed-env`, or if the user wants different values for these env vars per runner type, then they should use `env-overrides`. Removing these hardcoded env vars would be a breaking change, so I'm only adding a deprecation warning at this time.

https://linear.app/n8n/issue/CAT-1105/multi-language-launcher-config