### PR TITLE
refactor: Support logging for multiple runners

### DIFF
--- a/internal/commands/launch.go
+++ b/internal/commands/launch.go
@@ -93,7 +93,7 @@ func (l *LaunchCommand) Execute(cfg *config.Config) error {
 
 		cmd := exec.CommandContext(ctx, cfg.Runner.Command, cfg.Runner.Args...)
 		cmd.Env = runnerEnv
-		cmd.Stdout, cmd.Stderr = logs.GetRunnerWriters()
+		cmd.Stdout, cmd.Stderr = logs.GetRunnerWriters("javascript")
 
 		if err := cmd.Start(); err != nil {
 			cancelHealthMonitor()

--- a/internal/logs/runner_writers.go
+++ b/internal/logs/runner_writers.go
@@ -2,6 +2,7 @@ package logs
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -45,10 +46,11 @@ func (w *RunnerWriter) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
-// GetRunnerWriters returns configured `stdout` and `stderr` writers for a runner.
-func GetRunnerWriters() (stdout io.Writer, stderr io.Writer) {
-	stdout = NewRunnerWriter(os.Stdout, "[Runner] ", "DEBUG", ColorCyan)
-	stderr = NewRunnerWriter(os.Stderr, "[Runner] ", "ERROR", ColorRed)
+// GetRunnerWriters returns configured `stdout` and `stderr` writers for a runner type.
+func GetRunnerWriters(runnerType string) (stdout io.Writer, stderr io.Writer) {
+	prefix := fmt.Sprintf("[runner-%s] ", runnerType)
+	stdout = NewRunnerWriter(os.Stdout, prefix, "DEBUG", ColorCyan)
+	stderr = NewRunnerWriter(os.Stderr, prefix, "ERROR", ColorRed)
 
 	return stdout, stderr
 }

--- a/internal/logs/runner_writers_test.go
+++ b/internal/logs/runner_writers_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRunnerWriter(t *testing.T) {
@@ -93,7 +94,7 @@ func TestRunnerWriter(t *testing.T) {
 }
 
 func TestGetRunnerWriters(t *testing.T) {
-	stdout, stderr := GetRunnerWriters()
+	stdout, stderr := GetRunnerWriters("javascript")
 
 	assert.NotNil(t, stdout, "GetRunnerWriters() stdout should not be nil")
 	assert.NotNil(t, stderr, "GetRunnerWriters() stderr should not be nil")
@@ -102,4 +103,25 @@ func TestGetRunnerWriters(t *testing.T) {
 	// verify `stdout` and `stderr` implement `io.Writer`
 	var _ io.Writer = stdout
 	var _ io.Writer = stderr
+}
+
+func TestGetRunnerWritersWithDifferentTypes(t *testing.T) {
+	GetRunnerWriters("javascript")
+	GetRunnerWriters("python")
+
+	var jsBuf, pyBuf bytes.Buffer
+	jsWriter := NewRunnerWriter(&jsBuf, "[runner-javascript] ", "DEBUG", ColorCyan)
+	pyWriter := NewRunnerWriter(&pyBuf, "[runner-python] ", "DEBUG", ColorCyan)
+
+	_, err := jsWriter.Write([]byte("test message"))
+	require.NoError(t, err)
+	_, err = pyWriter.Write([]byte("test message"))
+	require.NoError(t, err)
+
+	jsOutput := jsBuf.String()
+	pyOutput := pyBuf.String()
+
+	assert.Contains(t, jsOutput, "[runner-javascript]", "JavaScript runner should have correct prefix")
+	assert.Contains(t, pyOutput, "[runner-python]", "Python runner should have correct prefix")
+	assert.NotEqual(t, jsOutput, pyOutput, "Different runner types should have different output")
 }


### PR DESCRIPTION
Make logging compatible for 1+ runners, as preparation for enabling the launcher to manage multiple runners.