### PR TITLE
refactor: Restructure config for multiple runners

### DIFF
--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -28,22 +28,22 @@ func main() {
 
 	runnerType := os.Args[1]
 
-	cfg, err := config.LoadConfig(runnerType, envconfig.OsLookuper())
+	launcherConfig, err := config.LoadLauncherConfig([]string{runnerType}, envconfig.OsLookuper())
 	if err != nil {
 		logs.Errorf("Failed to load config: %v", err)
 		os.Exit(1)
 	}
 
-	logs.SetLevel(cfg.LogLevel)
+	logs.SetLevel(launcherConfig.BaseConfig.LogLevel)
 
-	errorreporting.Init(cfg.Sentry)
+	errorreporting.Init(launcherConfig.BaseConfig.Sentry)
 	defer errorreporting.Close()
 
-	http.InitHealthCheckServer(cfg.HealthCheckServerPort)
+	http.InitHealthCheckServer(launcherConfig.BaseConfig.HealthCheckServerPort)
 
 	cmd := &commands.LaunchCommand{}
 
-	if err := cmd.Execute(cfg); err != nil {
+	if err := cmd.Execute(launcherConfig, runnerType); err != nil {
 		logs.Errorf("Failed to execute `launch` command: %s", err)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -56,7 +56,6 @@ func TestLoadConfig(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			configPath = testConfigPath
 
@@ -64,7 +63,7 @@ func TestLoadConfig(t *testing.T) {
 			require.NoError(t, err, "Failed to write test config file")
 
 			lookuper := envconfig.MapLookuper(tt.envVars)
-			cfg, err := LoadConfig(tt.runnerType, lookuper)
+			cfg, err := LoadLauncherConfig([]string{"javascript"}, lookuper)
 
 			if tt.expectedError {
 				assert.Error(t, err)
@@ -136,7 +135,7 @@ func TestConfigFileErrors(t *testing.T) {
 			}
 
 			lookuper := envconfig.MapLookuper(tt.envVars)
-			cfg, err := LoadConfig("javascript", lookuper)
+			cfg, err := LoadLauncherConfig([]string{"javascript"}, lookuper)
 
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tt.expectedError)


### PR DESCRIPTION
Restructure config for multiple runners, so we can later have a goroutine running one launcher per runner type.

Tested [locally](https://share.cleanshot.com/m1FbNH5d).