### PR TITLE
refactor: Prefix logs with runner type

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,19 @@ CLI utility to launch an [n8n task runner](https://docs.n8n.io/hosting/configura
 
 ```
 ./task-runner-launcher javascript
-2024/11/29 13:37:46 INFO  Starting launcher...
-2024/11/29 13:37:46 DEBUG Changed into working directory
-2024/11/29 13:37:46 DEBUG Prepared env vars for runner
-2024/11/29 13:37:46 INFO  Waiting for task broker to be ready...
-2024/11/29 13:37:46 DEBUG Task broker is ready
-2024/11/29 13:37:46 DEBUG Fetched grant token for launcher
-2024/11/29 13:37:46 DEBUG Launcher's runner ID: fc6c24b9f764ae55
-2024/11/29 13:37:46 DEBUG Connected: ws://127.0.0.1:5679/runners/_ws?id=fc6c24b9f764ae55
-2024/11/29 13:37:46 DEBUG <- Received message `broker:inforequest`
-2024/11/29 13:37:46 DEBUG -> Sent message `runner:info`
-2024/11/29 13:37:46 DEBUG <- Received message `broker:runnerregistered`
-2024/11/29 13:37:46 DEBUG -> Sent message `runner:taskoffer` for offer ID `5990b980a04945bd`
-2024/11/29 13:37:46 INFO  Waiting for launcher's task offer to be accepted...
+2024/11/29 13:37:46 INFO  [launcher:js] Starting launcher goroutine...
+2024/11/29 13:37:46 DEBUG [launcher:js] Changed into working directory
+2024/11/29 13:37:46 DEBUG [launcher:js] Prepared env vars for runner
+2024/11/29 13:37:46 INFO  [launcher:js] Waiting for task broker to be ready...
+2024/11/29 13:37:46 DEBUG [launcher:js] Task broker is ready
+2024/11/29 13:37:46 DEBUG [launcher:js] Fetched grant token for launcher
+2024/11/29 13:37:46 DEBUG [launcher:js] Launcher ID: fc6c24b9f764ae55
+2024/11/29 13:37:46 DEBUG [launcher:js] Connected: ws://127.0.0.1:5679/runners/_ws?id=fc6c24b9f764ae55
+2024/11/29 13:37:46 DEBUG [launcher:js] <- Received message `broker:inforequest`
+2024/11/29 13:37:46 DEBUG [launcher:js] -> Sent message `runner:info`
+2024/11/29 13:37:46 DEBUG [launcher:js] <- Received message `broker:runnerregistered`
+2024/11/29 13:37:46 DEBUG [launcher:js] -> Sent message `runner:taskoffer` for offer ID `5990b980a04945bd`
+2024/11/29 13:37:46 INFO  [launcher:js] Waiting for launcher's task offer to be accepted...
 ```
 
 ## Sections

--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -34,14 +34,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	logs.SetLevel(launcherConfig.BaseConfig.LogLevel)
-
 	errorreporting.Init(launcherConfig.BaseConfig.Sentry)
 	defer errorreporting.Close()
 
 	http.InitHealthCheckServer(launcherConfig.BaseConfig.HealthCheckServerPort)
 
-	cmd := &commands.LaunchCommand{}
+	logLevel := logs.ParseLevel(launcherConfig.BaseConfig.LogLevel)
+	logPrefix := logs.GetLauncherPrefix(runnerType)
+	logger := logs.NewLogger(logLevel, logPrefix)
+
+	cmd := commands.NewLaunchCommand(logger)
 
 	if err := cmd.Execute(launcherConfig, runnerType); err != nil {
 		logs.Errorf("Failed to execute `launch` command: %s", err)

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -112,15 +112,13 @@ var requiredRuntimeEnvVars = []string{
 }
 
 // PrepareRunnerEnv prepares the environment variables to pass to the runner.
-func PrepareRunnerEnv(baseConfig *config.BaseConfig, runnerConfig *config.RunnerConfig) []string {
+func PrepareRunnerEnv(baseConfig *config.BaseConfig, runnerConfig *config.RunnerConfig, logger *logs.Logger) []string {
 	checkLegacyBehavior(runnerConfig)
 
 	defaultEnvs := []string{"LANG", "PATH", "TZ", "TERM"}
 	allowedEnvs := append(defaultEnvs, runnerConfig.AllowedEnv...)
 
-	includedEnvs, excludedEnvs := partitionByAllowlist(allowedEnvs)
-
-	logs.Debugf("Env vars to exclude from runner: %v", keys(excludedEnvs))
+	includedEnvs, _ := partitionByAllowlist(allowedEnvs)
 
 	runnerEnv := includedEnvs
 	for _, envVar := range requiredRuntimeEnvVars {
@@ -135,14 +133,14 @@ func PrepareRunnerEnv(baseConfig *config.BaseConfig, runnerConfig *config.Runner
 
 	for key, value := range runnerConfig.EnvOverrides {
 		if slices.Contains(requiredRuntimeEnvVars, key) {
-			logs.Warnf("Disregarded env-override for required runtime variable: %s", key)
+			logger.Warnf("Disregarded env-override for required runtime variable: %s", key)
 			continue
 		}
 		runnerEnv = Clear(runnerEnv, key)
 		runnerEnv = append(runnerEnv, fmt.Sprintf("%s=%s", key, value))
 	}
 
-	logs.Debugf("Env vars to pass to runner: %v", keys(runnerEnv))
+	logger.Debugf("Env vars to pass to runner: %v", keys(runnerEnv))
 
 	return runnerEnv
 }

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"sort"
 	"task-runner-launcher/internal/config"
+	"task-runner-launcher/internal/logs"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -341,7 +342,8 @@ func TestPrepareRunnerEnv(t *testing.T) {
 				tt.setupFunc()
 			}
 
-			got := PrepareRunnerEnv(tt.launcherConfig.BaseConfig, tt.launcherConfig.RunnerConfigs["javascript"])
+			logger := logs.NewLogger(logs.InfoLevel, "")
+			got := PrepareRunnerEnv(tt.launcherConfig.BaseConfig, tt.launcherConfig.RunnerConfigs["javascript"], logger)
 			sort.Strings(got)
 
 			if !reflect.DeepEqual(got, tt.expected) {

--- a/internal/http/check_until_broker_ready.go
+++ b/internal/http/check_until_broker_ready.go
@@ -26,8 +26,8 @@ func sendHealthRequest(taskBrokerURI string) (*http.Response, error) {
 // CheckUntilBrokerReady checks forever until the task broker is ready, i.e.
 // In case of long-running migrations, readiness may take a long time.
 // Returns nil when ready.
-func CheckUntilBrokerReady(taskBrokerURI string) error {
-	logs.Info("Waiting for task broker to be ready...")
+func CheckUntilBrokerReady(taskBrokerURI string, logger *logs.Logger) error {
+	logger.Info("Waiting for task broker to be ready...")
 
 	healthCheck := func() (string, error) {
 		resp, err := sendHealthRequest(taskBrokerURI)
@@ -47,7 +47,7 @@ func CheckUntilBrokerReady(taskBrokerURI string) error {
 		return err
 	}
 
-	logs.Debug("Task broker is ready")
+	logger.Debug("Task broker is ready")
 
 	return nil
 }

--- a/internal/http/check_until_broker_ready_test.go
+++ b/internal/http/check_until_broker_ready_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"task-runner-launcher/internal/logs"
 	"testing"
 	"time"
 
@@ -43,7 +44,8 @@ func TestCheckUntilBrokerReadyHappyPath(t *testing.T) {
 
 			done := make(chan error)
 			go func() {
-				done <- CheckUntilBrokerReady(srv.URL)
+				logger := logs.NewLogger(logs.InfoLevel, "")
+				done <- CheckUntilBrokerReady(srv.URL, logger)
 			}()
 
 			select {
@@ -97,7 +99,8 @@ func TestCheckUntilBrokerReadyErrors(t *testing.T) {
 
 			brokerUnexpectedlyReady := make(chan error)
 			go func() {
-				brokerUnexpectedlyReady <- CheckUntilBrokerReady(srv.URL)
+				logger := logs.NewLogger(logs.InfoLevel, "")
+				brokerUnexpectedlyReady <- CheckUntilBrokerReady(srv.URL, logger)
 			}()
 
 			select {

--- a/internal/http/manage_runner_health_test.go
+++ b/internal/http/manage_runner_health_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"sync"
 	"syscall"
+	"task-runner-launcher/internal/logs"
 	"testing"
 	"time"
 
@@ -117,7 +118,8 @@ func TestMonitorRunnerHealth(t *testing.T) {
 			defer cancel()
 
 			var wg sync.WaitGroup
-			resultChan := monitorRunnerHealth(ctx, srv.URL, &wg)
+			logger := logs.NewLogger(logs.InfoLevel, "")
+			resultChan := monitorRunnerHealth(ctx, srv.URL, &wg, logger)
 
 			result := <-resultChan
 			assert.Equal(t, tt.expectedStatus, result.Status, "unexpected health status")
@@ -166,7 +168,8 @@ func TestManageRunnerHealth(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 			defer cancel()
 
-			ManageRunnerHealth(ctx, cmd, srv.URL, &wg)
+			logger := logs.NewLogger(logs.InfoLevel, "")
+			ManageRunnerHealth(ctx, cmd, srv.URL, &wg, logger)
 
 			// For a healthy runner, we wait long enough for 3 health checks to pass.
 			// For an unhealthy runner, we wait long enough for 2 health checks to
@@ -202,8 +205,9 @@ func TestContextCancellation(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
+	logger := logs.NewLogger(logs.InfoLevel, "")
 
-	resultChan := monitorRunnerHealth(ctx, srv.URL, &wg)
+	resultChan := monitorRunnerHealth(ctx, srv.URL, &wg, logger)
 
 	time.Sleep(20 * time.Millisecond) // short-lived until context is cancelled
 	cancel()

--- a/internal/logs/logger.go
+++ b/internal/logs/logger.go
@@ -41,75 +41,100 @@ func Init() {
 	}
 }
 
+var abbreviations = map[string]string{
+	"javascript": "js",
+	"python":     "py",
+}
+
+// GetLauncherPrefix returns the formatted prefix for launcher logs
+func GetLauncherPrefix(runnerType string) string {
+	if abbr, ok := abbreviations[runnerType]; ok {
+		return fmt.Sprintf("[launcher:%s] ", abbr)
+	}
+
+	return fmt.Sprintf("[launcher:%s] ", runnerType)
+}
+
+// GetRunnerPrefix returns the formatted prefix for runner logs
+func GetRunnerPrefix(runnerType string) string {
+	if abbr, ok := abbreviations[runnerType]; ok {
+		return fmt.Sprintf("[runner:%s] ", abbr)
+	}
+
+	return fmt.Sprintf("[runner:%s] ", runnerType)
+}
+
 // ------------------------
 //         logger
 // ------------------------
 
 type Logger struct {
-	debug *log.Logger
-	info  *log.Logger
-	warn  *log.Logger
-	err   *log.Logger
-	level Level
+	debug  *log.Logger
+	info   *log.Logger
+	warn   *log.Logger
+	err    *log.Logger
+	level  Level
+	prefix string
 }
 
-func NewLogger(level Level) *Logger {
+func NewLogger(level Level, prefix string) *Logger {
 	return &Logger{
-		debug: log.New(os.Stdout, "", log.LstdFlags),
-		info:  log.New(os.Stdout, "", log.LstdFlags),
-		warn:  log.New(os.Stdout, "", log.LstdFlags),
-		err:   log.New(os.Stderr, "", log.LstdFlags),
-		level: level,
+		debug:  log.New(os.Stdout, "", log.LstdFlags),
+		info:   log.New(os.Stdout, "", log.LstdFlags),
+		warn:   log.New(os.Stdout, "", log.LstdFlags),
+		err:    log.New(os.Stderr, "", log.LstdFlags),
+		level:  level,
+		prefix: prefix,
 	}
 }
 
-var logger = NewLogger(InfoLevel)
+var logger = NewLogger(InfoLevel, "")
 
 func (l *Logger) Debug(msg string) {
 	if l.level <= DebugLevel {
-		l.debug.Printf("%sDEBUG %s%s", ColorCyan, msg, ColorReset)
+		l.debug.Printf("%sDEBUG %s%s%s", ColorCyan, l.prefix, msg, ColorReset)
 	}
 }
 
 func (l *Logger) Debugf(msg string, xs ...interface{}) {
 	if l.level <= DebugLevel {
-		l.debug.Printf(fmt.Sprintf("%sDEBUG %s%s", ColorCyan, msg, ColorReset), xs...)
+		l.debug.Printf(fmt.Sprintf("%sDEBUG %s%s%s", ColorCyan, l.prefix, msg, ColorReset), xs...)
 	}
 }
 
 func (l *Logger) Info(msg string) {
 	if l.level <= InfoLevel {
-		l.info.Printf("%sINFO  %s%s", ColorBlue, msg, ColorReset)
+		l.info.Printf("%sINFO  %s%s%s", ColorBlue, l.prefix, msg, ColorReset)
 	}
 }
 
 func (l *Logger) Infof(msg string, xs ...interface{}) {
 	if l.level <= InfoLevel {
-		l.info.Printf(fmt.Sprintf("%sINFO  %s%s", ColorBlue, msg, ColorReset), xs...)
+		l.info.Printf(fmt.Sprintf("%sINFO  %s%s%s", ColorBlue, l.prefix, msg, ColorReset), xs...)
 	}
 }
 
 func (l *Logger) Warn(msg string) {
 	if l.level <= WarnLevel {
-		l.warn.Printf("%sWARN %s%s", ColorYellow, msg, ColorReset)
+		l.warn.Printf("%sWARN %s%s%s", ColorYellow, l.prefix, msg, ColorReset)
 	}
 }
 
 func (l *Logger) Warnf(msg string, xs ...interface{}) {
 	if l.level <= WarnLevel {
-		l.warn.Printf(fmt.Sprintf("%sWARN %s%s", ColorYellow, msg, ColorReset), xs...)
+		l.warn.Printf(fmt.Sprintf("%sWARN %s%s%s", ColorYellow, l.prefix, msg, ColorReset), xs...)
 	}
 }
 
 func (l *Logger) Error(msg string) {
 	if l.level <= ErrorLevel {
-		l.warn.Printf("%sERROR %s%s", ColorRed, msg, ColorReset)
+		l.warn.Printf("%sERROR %s%s%s", ColorRed, l.prefix, msg, ColorReset)
 	}
 }
 
 func (l *Logger) Errorf(msg string, xs ...interface{}) {
 	if l.level <= ErrorLevel {
-		l.err.Printf(fmt.Sprintf("%sERROR %s%s", ColorRed, msg, ColorReset), xs...)
+		l.err.Printf(fmt.Sprintf("%sERROR %s%s%s", ColorRed, l.prefix, msg, ColorReset), xs...)
 	}
 }
 
@@ -117,16 +142,12 @@ func (l *Logger) Errorf(msg string, xs ...interface{}) {
 //          API
 // ------------------------
 
-func parseLevel(level string) Level {
+func ParseLevel(level string) Level {
 	if lvl, ok := levelMap[strings.ToLower(level)]; ok {
 		return lvl
 	}
 
 	return InfoLevel
-}
-
-func SetLevel(level string) {
-	logger.level = parseLevel(level)
 }
 
 func Debug(msg string) {

--- a/internal/logs/logger_test.go
+++ b/internal/logs/logger_test.go
@@ -51,57 +51,6 @@ func runLogTests(t *testing.T, tests []logTest) {
 	}
 }
 
-func TestSetLevel(t *testing.T) {
-	tests := []struct {
-		name          string
-		level         string
-		expectedLevel Level
-	}{
-		{
-			name:          "debug level",
-			level:         "debug",
-			expectedLevel: DebugLevel,
-		},
-		{
-			name:          "info level",
-			level:         "info",
-			expectedLevel: InfoLevel,
-		},
-		{
-			name:          "warn level",
-			level:         "warn",
-			expectedLevel: WarnLevel,
-		},
-		{
-			name:          "error level",
-			level:         "error",
-			expectedLevel: ErrorLevel,
-		},
-		{
-			name:          "empty level defaults to info",
-			level:         "",
-			expectedLevel: InfoLevel,
-		},
-		{
-			name:          "invalid level defaults to info",
-			level:         "invalid",
-			expectedLevel: InfoLevel,
-		},
-		{
-			name:          "case-insensitive level handling",
-			level:         "DEBUG",
-			expectedLevel: DebugLevel,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			SetLevel(tt.level)
-			assert.Equal(t, tt.expectedLevel, logger.level, "Logger level should be set correctly")
-		})
-	}
-}
-
 func TestDebugLogs(t *testing.T) {
 	tests := []logTest{
 		{
@@ -269,4 +218,76 @@ func TestColorDisabling(t *testing.T) {
 	ColorYellow = origYellow
 	ColorBlue = origBlue
 	ColorCyan = origCyan
+}
+
+func TestGetLauncherPrefix(t *testing.T) {
+	tests := []struct {
+		name       string
+		runnerType string
+		expected   string
+	}{
+		{
+			name:       "javascript abbreviation",
+			runnerType: "javascript",
+			expected:   "[launcher:js] ",
+		},
+		{
+			name:       "python abbreviation",
+			runnerType: "python",
+			expected:   "[launcher:py] ",
+		},
+		{
+			name:       "unknown runner type uses raw name",
+			runnerType: "rust",
+			expected:   "[launcher:rust] ",
+		},
+		{
+			name:       "custom runner type",
+			runnerType: "custom-runner",
+			expected:   "[launcher:custom-runner] ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetLauncherPrefix(tt.runnerType)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetRunnerPrefix(t *testing.T) {
+	tests := []struct {
+		name       string
+		runnerType string
+		expected   string
+	}{
+		{
+			name:       "javascript abbreviation",
+			runnerType: "javascript",
+			expected:   "[runner:js] ",
+		},
+		{
+			name:       "python abbreviation",
+			runnerType: "python",
+			expected:   "[runner:py] ",
+		},
+		{
+			name:       "unknown runner type uses raw name",
+			runnerType: "go",
+			expected:   "[runner:go] ",
+		},
+		{
+			name:       "custom runner type",
+			runnerType: "my-custom-runner",
+			expected:   "[runner:my-custom-runner] ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetRunnerPrefix(tt.runnerType)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }

--- a/internal/logs/runner_writers.go
+++ b/internal/logs/runner_writers.go
@@ -2,7 +2,6 @@ package logs
 
 import (
 	"bufio"
-	"fmt"
 	"io"
 	"log"
 	"os"
@@ -46,9 +45,8 @@ func (w *RunnerWriter) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
-// GetRunnerWriters returns configured `stdout` and `stderr` writers for a runner type.
-func GetRunnerWriters(runnerType string) (stdout io.Writer, stderr io.Writer) {
-	prefix := fmt.Sprintf("[runner-%s] ", runnerType)
+// GetRunnerWriters returns configured `stdout` and `stderr` writers with a custom prefix.
+func GetRunnerWriters(prefix string) (stdout io.Writer, stderr io.Writer) {
 	stdout = NewRunnerWriter(os.Stdout, prefix, "DEBUG", ColorCyan)
 	stderr = NewRunnerWriter(os.Stderr, prefix, "ERROR", ColorRed)
 

--- a/internal/logs/runner_writers_test.go
+++ b/internal/logs/runner_writers_test.go
@@ -94,7 +94,8 @@ func TestRunnerWriter(t *testing.T) {
 }
 
 func TestGetRunnerWriters(t *testing.T) {
-	stdout, stderr := GetRunnerWriters("javascript")
+	prefix := "[runner:js] "
+	stdout, stderr := GetRunnerWriters(prefix)
 
 	assert.NotNil(t, stdout, "GetRunnerWriters() stdout should not be nil")
 	assert.NotNil(t, stderr, "GetRunnerWriters() stderr should not be nil")
@@ -106,12 +107,12 @@ func TestGetRunnerWriters(t *testing.T) {
 }
 
 func TestGetRunnerWritersWithDifferentTypes(t *testing.T) {
-	GetRunnerWriters("javascript")
-	GetRunnerWriters("python")
+	GetRunnerWriters("[runner:js] ")
+	GetRunnerWriters("[runner:py] ")
 
 	var jsBuf, pyBuf bytes.Buffer
-	jsWriter := NewRunnerWriter(&jsBuf, "[runner-javascript] ", "DEBUG", ColorCyan)
-	pyWriter := NewRunnerWriter(&pyBuf, "[runner-python] ", "DEBUG", ColorCyan)
+	jsWriter := NewRunnerWriter(&jsBuf, "[runner:js] ", "DEBUG", ColorCyan)
+	pyWriter := NewRunnerWriter(&pyBuf, "[runner:py] ", "DEBUG", ColorCyan)
 
 	_, err := jsWriter.Write([]byte("test message"))
 	require.NoError(t, err)
@@ -121,7 +122,7 @@ func TestGetRunnerWritersWithDifferentTypes(t *testing.T) {
 	jsOutput := jsBuf.String()
 	pyOutput := pyBuf.String()
 
-	assert.Contains(t, jsOutput, "[runner-javascript]", "JavaScript runner should have correct prefix")
-	assert.Contains(t, pyOutput, "[runner-python]", "Python runner should have correct prefix")
+	assert.Contains(t, jsOutput, "[runner:js]", "JavaScript runner should have correct prefix")
+	assert.Contains(t, pyOutput, "[runner:py]", "Python runner should have correct prefix")
 	assert.NotEqual(t, jsOutput, pyOutput, "Different runner types should have different output")
 }


### PR DESCRIPTION
Give every launcher goroutine its own log prefix. Last step before turning the main loop into a goroutine per runner type.