### PR TITLE
fix: Make runner log writers respect 'N8N_RUNNERS_LAUNCHER_LOG_LEVEL' default

### DIFF
--- a/internal/commands/launch.go
+++ b/internal/commands/launch.go
@@ -104,7 +104,8 @@ func (c *LaunchCommand) Execute(launcherConfig *config.LauncherConfig, runnerTyp
 		cmd := exec.CommandContext(ctx, runnerConfig.Command, runnerConfig.Args...)
 		cmd.Env = runnerEnv
 		runnerPrefix := logs.GetRunnerPrefix(runnerType)
-		cmd.Stdout, cmd.Stderr = logs.GetRunnerWriters(runnerPrefix)
+		logLevel := logs.ParseLevel(launcherConfig.BaseConfig.LogLevel)
+		cmd.Stdout, cmd.Stderr = logs.GetRunnerWriters(logLevel, runnerPrefix)
 
 		if err := cmd.Start(); err != nil {
 			cancelHealthMonitor()

--- a/internal/logs/logger.go
+++ b/internal/logs/logger.go
@@ -23,6 +23,17 @@ var levelMap = map[string]Level{
 	"error": ErrorLevel,
 }
 
+var levelNames = map[Level]string{
+	DebugLevel: "DEBUG",
+	InfoLevel:  "INFO",
+	WarnLevel:  "WARN",
+	ErrorLevel: "ERROR",
+}
+
+func (l Level) String() string {
+	return levelNames[l]
+}
+
 var (
 	ColorReset  = "\033[0m"
 	ColorRed    = "\033[31m"

--- a/internal/logs/runner_writers.go
+++ b/internal/logs/runner_writers.go
@@ -10,42 +10,28 @@ import (
 
 // RunnerWriter wraps runner output with timestamps and prefixes.
 type RunnerWriter struct {
-	writer *log.Logger
-	prefix string
-	level  string
-	color  string
+	writer   *log.Logger
+	prefix   string
+	color    string
+	level    Level
+	minLevel Level
 }
 
 // NewRunnerWriter creates a new wrapper for runner output.
-func NewRunnerWriter(w io.Writer, prefix string, level string, color string) *RunnerWriter {
+func NewRunnerWriter(w io.Writer, prefix string, color string, level Level, minLevel Level) *RunnerWriter {
 	return &RunnerWriter{
-		writer: log.New(w, "", log.LstdFlags),
-		prefix: prefix,
-		level:  level,
-		color:  color,
-	}
-}
-
-var (
-	shouldLogDebug  bool
-	logLevelChecked bool
-)
-
-func initLogLevel() {
-	if !logLevelChecked {
-		logLevel := strings.ToUpper(os.Getenv("N8N_RUNNERS_LAUNCHER_LOG_LEVEL"))
-		shouldLogDebug = logLevel == "DEBUG" || logLevel == ""
-		logLevelChecked = true
+		writer:   log.New(w, "", log.LstdFlags),
+		prefix:   prefix,
+		level:    level,
+		color:    color,
+		minLevel: minLevel,
 	}
 }
 
 // Write implements `io.Writer` and adds color, timestamp, level and a prefix to each line.
 func (w *RunnerWriter) Write(p []byte) (n int, err error) {
-	if w.level == "DEBUG" {
-		initLogLevel()
-		if !shouldLogDebug {
-			return len(p), nil
-		}
+	if w.level < w.minLevel {
+		return len(p), nil
 	}
 
 	scanner := bufio.NewScanner(strings.NewReader(string(p)))
@@ -66,9 +52,9 @@ func (w *RunnerWriter) Write(p []byte) (n int, err error) {
 }
 
 // GetRunnerWriters returns configured `stdout` and `stderr` writers with a custom prefix.
-func GetRunnerWriters(prefix string) (stdout io.Writer, stderr io.Writer) {
-	stdout = NewRunnerWriter(os.Stdout, prefix, "DEBUG", ColorCyan)
-	stderr = NewRunnerWriter(os.Stderr, prefix, "ERROR", ColorRed)
+func GetRunnerWriters(minLevel Level, prefix string) (stdout io.Writer, stderr io.Writer) {
+	stdout = NewRunnerWriter(os.Stdout, prefix, ColorCyan, DebugLevel, minLevel)
+	stderr = NewRunnerWriter(os.Stderr, prefix, ColorRed, ErrorLevel, minLevel)
 
 	return stdout, stderr
 }

--- a/internal/logs/runner_writers_test.go
+++ b/internal/logs/runner_writers_test.go
@@ -14,17 +14,19 @@ func TestRunnerWriter(t *testing.T) {
 		name          string
 		input         string
 		prefix        string
-		level         string
 		color         string
+		level         Level
+		minLevel      Level
 		expectedParts []string
 		skipParts     []string
 	}{
 		{
-			name:   "writes single line with correct format",
-			input:  "test message",
-			prefix: "[Test] ",
-			level:  "INFO",
-			color:  ColorBlue,
+			name:     "writes single line with correct format",
+			input:    "test message",
+			prefix:   "[Test] ",
+			color:    ColorBlue,
+			level:    InfoLevel,
+			minLevel: DebugLevel,
 			expectedParts: []string{
 				ColorBlue,
 				"INFO",
@@ -34,11 +36,28 @@ func TestRunnerWriter(t *testing.T) {
 			},
 		},
 		{
-			name:   "handles multiple lines",
-			input:  "line1\nline2\nline3",
-			prefix: "[Runner] ",
-			level:  "DEBUG",
-			color:  ColorCyan,
+			name:          "skips messages below min log level",
+			input:         "test message",
+			prefix:        "[Test] ",
+			color:         ColorBlue,
+			level:         DebugLevel,
+			minLevel:      InfoLevel,
+			expectedParts: []string{},
+			skipParts: []string{
+				ColorBlue,
+				"INFO",
+				"[Test] ",
+				"test message",
+				ColorReset,
+			},
+		},
+		{
+			name:     "handles multiple lines",
+			input:    "line1\nline2\nline3",
+			prefix:   "[Runner] ",
+			color:    ColorCyan,
+			level:    DebugLevel,
+			minLevel: DebugLevel,
 			expectedParts: []string{
 				"[Runner] line1",
 				"[Runner] line2",
@@ -46,11 +65,12 @@ func TestRunnerWriter(t *testing.T) {
 			},
 		},
 		{
-			name:   "skips empty lines",
-			input:  "line1\n\n\nline2",
-			prefix: "[Test] ",
-			level:  "INFO",
-			color:  ColorBlue,
+			name:     "skips empty lines",
+			input:    "line1\n\n\nline2",
+			prefix:   "[Test] ",
+			color:    ColorBlue,
+			level:    InfoLevel,
+			minLevel: DebugLevel,
 			expectedParts: []string{
 				"[Test] line1",
 				"[Test] line2",
@@ -60,11 +80,12 @@ func TestRunnerWriter(t *testing.T) {
 			},
 		},
 		{
-			name:   "respects whitespace in message",
-			input:  "  indented message  ",
-			prefix: "[Test] ",
-			level:  "DEBUG",
-			color:  ColorCyan,
+			name:     "respects whitespace in message",
+			input:    "  indented message  ",
+			prefix:   "[Test] ",
+			color:    ColorCyan,
+			level:    DebugLevel,
+			minLevel: DebugLevel,
 			expectedParts: []string{
 				"[Test]   indented message  ",
 			},
@@ -74,7 +95,7 @@ func TestRunnerWriter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			writer := NewRunnerWriter(&buf, tt.prefix, tt.level, tt.color)
+			writer := NewRunnerWriter(&buf, tt.prefix, tt.color, tt.level, tt.minLevel)
 
 			n, err := writer.Write([]byte(tt.input))
 			assert.NoError(t, err, "RunnerWriter.Write() should not return an error")
@@ -95,7 +116,7 @@ func TestRunnerWriter(t *testing.T) {
 
 func TestGetRunnerWriters(t *testing.T) {
 	prefix := "[runner:js] "
-	stdout, stderr := GetRunnerWriters(prefix)
+	stdout, stderr := GetRunnerWriters(DebugLevel, prefix)
 
 	assert.NotNil(t, stdout, "GetRunnerWriters() stdout should not be nil")
 	assert.NotNil(t, stderr, "GetRunnerWriters() stderr should not be nil")
@@ -107,12 +128,12 @@ func TestGetRunnerWriters(t *testing.T) {
 }
 
 func TestGetRunnerWritersWithDifferentTypes(t *testing.T) {
-	GetRunnerWriters("[runner:js] ")
-	GetRunnerWriters("[runner:py] ")
+	GetRunnerWriters(DebugLevel, "[runner:js] ")
+	GetRunnerWriters(DebugLevel, "[runner:py] ")
 
 	var jsBuf, pyBuf bytes.Buffer
-	jsWriter := NewRunnerWriter(&jsBuf, "[runner:js] ", "DEBUG", ColorCyan)
-	pyWriter := NewRunnerWriter(&pyBuf, "[runner:py] ", "DEBUG", ColorCyan)
+	jsWriter := NewRunnerWriter(&jsBuf, "[runner:js] ", ColorCyan, DebugLevel, DebugLevel)
+	pyWriter := NewRunnerWriter(&pyBuf, "[runner:py] ", ColorCyan, DebugLevel, DebugLevel)
 
 	_, err := jsWriter.Write([]byte("test message"))
 	require.NoError(t, err)


### PR DESCRIPTION
We default `N8N_RUNNERS_LAUNCHER_LOG_LEVEL` to `info` currently on task-runner-launcher/internal/config/config.go, but this default was never passed to the runner writers, causing them to log on `debug` level if the env was unset.

I changed the implementation so that the env default gets passed from the same config where we parse envs instead of reading its value from env here. At least to me it seems like a good idea that these respect the launcher's log level as a min level to log on.

https://linear.app/n8n/issue/CAT-1345/disable-debug-logging-on-the-new-task-runner-container