### PR TITLE
chore: Update Go to 1.25.5

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,7 +8,7 @@ jobs:
 
       - uses: actions/setup-go@v5.1.0
         with:
-          go-version: 1.25.3
+          go-version: 1.25.5
 
       - name: Lint
         uses: golangci/golangci-lint-action@v8.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
-          goversion: 1.25.3
+          goversion: 1.25.5
           binary_name: task-runner-launcher
           project_path: ./cmd/launcher
           sha256sum: true

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,7 +2,7 @@
 
 To set up a development environment, follow these steps:
 
-1. Install Go >=1.25.3, [`golangci-lint`](https://golangci-lint.run/welcome/install/) >= 2.4.0 and `make`.
+1. Install Go >=1.25.5, [`golangci-lint`](https://golangci-lint.run/welcome/install/) >= 2.4.0 and `make`.
 
 2. Clone this repository and create a [config file](setup.md#config-file).
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module task-runner-launcher
 
-go 1.25.3
+go 1.25.5
 
 require (
 	github.com/getsentry/sentry-go v0.35.2


### PR DESCRIPTION
Fixes 
- CVE-2025-61729
- CVE-2025-61727

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the project to Go 1.25.5 across code, CI, and docs to pull in security fixes. Ensures all builds use the patched toolchain addressing recent CVEs.

- **Dependencies**
  - Set go 1.25.5 in go.mod.
  - Updated actions/workflows (checks, release) to 1.25.5.
  - Raised docs requirement to Go >=1.25.5.

- **Bug Fixes**
  - Uses the patched Go toolchain to include the latest security fixes.

<sup>Written for commit f3a24cee8ff6375a5cac05221c098fc3e0a0d6f8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

