### PR TITLE
docs: Update release instructions

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -1,14 +1,8 @@
 # Release
 
-1. Publish a [GitHub release](https://github.com/n8n-io/task-runner-launcher/releases/new) with a git tag following semver.
-
-The [`release` workflow](../.github/workflows/release.yml) will build binaries for arm64 and amd64 and upload them to the release in the [releases page](https://github.com/n8n-io/task-runner-launcher/releases).
-
-> [!WARNING]
-> When publishing the GitHub release, mark it as `latest` and NOT as `pre-release` or the `release` workflow will not run.
+1. Publish a [GitHub release](https://github.com/n8n-io/task-runner-launcher/releases/new) with a new git tag following semver. The [`release` workflow](../.github/workflows/release.yml) will build binaries for arm64 and amd64 and upload them to the release in the [releases page](https://github.com/n8n-io/task-runner-launcher/releases).
 
 2. Update the `LAUNCHER_VERSION` argument in the main repository:
 
-- `docker/images/n8n/Dockerfile`
 - `docker/images/runners/Dockerfile`
 - `docker/images/runners/Dockerfile.distroless`


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Streamlined the release guide by consolidating the GitHub release step and removing the outdated “latest vs pre-release” warning. Corrected the files to update LAUNCHER_VERSION, dropping docker/images/n8n/Dockerfile.

<sup>Written for commit d2288175a5608c358fb4633c8a83d84f18a064b6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

