### PR TITLE
fix: Update go to 1.25.8

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,7 +8,7 @@ jobs:
 
       - uses: actions/setup-go@v5.1.0
         with:
-          go-version: 1.25.7
+          go-version: 1.25.8
 
       - name: Lint
         uses: golangci/golangci-lint-action@v8.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
-          goversion: 1.25.7
+          goversion: 1.25.8
           binary_name: task-runner-launcher
           project_path: ./cmd/launcher
           sha256sum: true

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,7 +2,7 @@
 
 To set up a development environment, follow these steps:
 
-1. Install Go >=1.25.7, [`golangci-lint`](https://golangci-lint.run/welcome/install/) >= 2.4.0 and `make`.
+1. Install Go >=1.25.8, [`golangci-lint`](https://golangci-lint.run/welcome/install/) >= 2.4.0 and `make`.
 
 2. Clone this repository and create a [config file](setup.md#config-file).
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module task-runner-launcher
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/getsentry/sentry-go v0.35.2


### PR DESCRIPTION
## Summary
- Bump Go from 1.25.7 to 1.25.8 (security patch) across `go.mod`, CI workflows, and docs

## Test plan
- [ ] CI checks pass with Go 1.25.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)