### PR TITLE
fix: Update go to 1.25.9

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,7 +8,7 @@ jobs:
 
       - uses: actions/setup-go@v5.1.0
         with:
-          go-version: 1.25.8
+          go-version: 1.25.9
 
       - name: Lint
         uses: golangci/golangci-lint-action@v8.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
-          goversion: 1.25.8
+          goversion: 1.25.9
           binary_name: task-runner-launcher
           project_path: ./cmd/launcher
           sha256sum: true

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,7 +2,7 @@
 
 To set up a development environment, follow these steps:
 
-1. Install Go >=1.25.8, [`golangci-lint`](https://golangci-lint.run/welcome/install/) >= 2.4.0 and `make`.
+1. Install Go >=1.25.9, [`golangci-lint`](https://golangci-lint.run/welcome/install/) >= 2.4.0 and `make`.
 
 2. Clone this repository and create a [config file](setup.md#config-file).
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module task-runner-launcher
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/getsentry/sentry-go v0.35.2


### PR DESCRIPTION
## Summary
- Bumps Go from 1.25.8 to 1.25.9 across `go.mod`, CI workflows, and development docs.
- Addresses CVEs flagged by Aikido against the launcher binary (CVE-2026-27143, -27140, -32281, -32283, -32280, -27144, -32282) which require Go 1.25.9.

## Test plan
- [ ] CI checks pass (lint, fmt, vet, tests) on the new Go version
- [ ] Release workflow builds cleanly on next tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)