### PR TITLE
fix: Don't panic when runner has already exited before termination

### DIFF
--- a/internal/http/manage_runner_health.go
+++ b/internal/http/manage_runner_health.go
@@ -2,8 +2,10 @@ package http
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"os/exec"
 	"sync"
 	"task-runner-launcher/internal/logs"
@@ -129,6 +131,14 @@ func ManageRunnerHealth(
 		case StatusUnhealthy:
 			logger.Warn("Found runner unresponsive too many times, terminating runner...")
 			if err := cmd.Process.Kill(); err != nil {
+				// The runner process may have already exited on its own
+				// (e.g. OOM-killed by the kernel) between the health check
+				// failing and this Kill call. Treat that as success since the
+				// goal of Kill — the process no longer running — is satisfied.
+				if errors.Is(err, os.ErrProcessDone) {
+					logger.Info("Runner process had already exited before termination; no signal sent")
+					break
+				}
 				panic(fmt.Errorf("failed to terminate unhealthy runner process: %v", err))
 			}
 		case StatusMonitoringCancelled:

--- a/internal/http/manage_runner_health_test.go
+++ b/internal/http/manage_runner_health_test.go
@@ -197,6 +197,43 @@ func TestManageRunnerHealth(t *testing.T) {
 	}
 }
 
+// TestManageRunnerHealthAlreadyExited verifies that the launcher does not
+// panic when the runner process has already exited between the health check
+// declaring it unhealthy and the launcher attempting to terminate it. This is
+// the os.ErrProcessDone race that surfaces in production when the runner is
+// OOM-killed (or otherwise dies) just before the launcher decides to kill it.
+func TestManageRunnerHealthAlreadyExited(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	cmd := exec.Command("sleep", "60")
+	require.NoError(t, cmd.Start(), "Failed to start dummy process")
+
+	// Reap the process so cmd.Process.Kill() returns os.ErrProcessDone, the
+	// same condition Go produces when the kernel has already collected the
+	// child between unhealthy detection and our Kill call.
+	require.NoError(t, cmd.Process.Kill(), "Failed to pre-kill dummy process")
+	_, _ = cmd.Process.Wait()
+
+	var wg sync.WaitGroup
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	logger := logs.NewLogger(logs.InfoLevel, "")
+
+	// Must not panic. Before this fix, ManageRunnerHealth panicked with
+	// "failed to terminate unhealthy runner process: os: process already
+	// finished" once the unhealthy threshold was crossed.
+	assert.NotPanics(t, func() {
+		ManageRunnerHealth(ctx, cmd, srv.URL, &wg, logger)
+		time.Sleep(healthCheckInterval * time.Duration(healthCheckMaxFailures+1))
+	}, "ManageRunnerHealth must not panic when the runner process has already exited")
+
+	wg.Wait()
+}
+
 func TestContextCancellation(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## Summary

`ManageRunnerHealth` panics with
`failed to terminate unhealthy runner process: os: process already finished`
when the runner has already exited between the unhealthy detection and the
launcher's `cmd.Process.Kill()` call. This is a TOCTOU race that the
launcher cannot prevent — Linux `kill(2)` returns `ESRCH` if the kernel
collected the child a moment earlier, and Go surfaces this as
`os.ErrProcessDone`.

The panic propagates to the whole launcher process. On Cloud Run /
Kubernetes this exits the runner container and triggers a cascading
restart for what should be a routine "child died, restart it" supervisor
signal.

Observed in production at the tail end of an unrelated stuck-runner
state (see "Related" below):

```
panic: failed to terminate unhealthy runner process: os: process already finished

goroutine 50243 [running]:
task-runner-launcher/internal/http.ManageRunnerHealth.func1()
	/github/workspace/internal/http/manage_runner_health.go:132 +0xc6
created by task-runner-launcher/internal/http.ManageRunnerHealth in goroutine 50229
	/github/workspace/internal/http/manage_runner_health.go:126 +0xa5
```

## Change

`Kill()` returning `os.ErrProcessDone` means the process was already gone
via another path, which is exactly the post-condition `Kill` was trying
to establish. Treat it as a no-op with an Info log and continue. Other
`Kill` errors still panic, matching prior behavior.

This mirrors the `os/exec` standard library's own pattern — `ErrProcessDone`
is filtered out of supervisor shutdown paths there because of the same
syscall-level race.

## Test

`TestManageRunnerHealthAlreadyExited` reaps the dummy process before
invoking `ManageRunnerHealth` so the subsequent `Kill()` returns
`ErrProcessDone`. Without this change the goroutine panic crashes the
test binary; with the change it passes.

## Related

The 11-hour stuck broker↔runner channel that preceded the panic is a
separate root cause and will be filed as an issue against `n8n-io/n8n`.
This PR is intentionally scoped to making the launcher robust to the
Kill race only, not to fix whatever caused the runner to be unresponsive
in the first place.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent launcher panics when an unhealthy runner has already exited by treating `os.ErrProcessDone` from Kill as success. This stops cascading container restarts and makes the health supervisor resilient to the kill race.

- **Bug Fixes**
  - Treat `os.ErrProcessDone` from `cmd.Process.Kill()` as a no-op with an Info log; other errors still panic, matching `os/exec` conventions.
  - Added regression test (`TestManageRunnerHealthAlreadyExited`) to ensure no panic when the runner exits before termination.

<sup>Written for commit af3ee7ca174b3d7aab76ba1ce847f17229ac94aa. Summary will update on new commits. <a href="https://cubic.dev/pr/n8n-io/task-runner-launcher/pull/98?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

