### PR TITLE
feat: Forward SIGTERM to the runner on shutdown and wait for graceful drain

### DIFF
--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
+	"os/signal"
 	"sync"
+	"syscall"
 	"task-runner-launcher/internal/commands"
 	"task-runner-launcher/internal/config"
 	"task-runner-launcher/internal/errorreporting"
@@ -39,6 +42,13 @@ func main() {
 
 	http.InitHealthCheckServer(launcherConfig.BaseConfig.HealthCheckServerPort)
 
+	// On SIGTERM/SIGINT (e.g. a k8s pod redeploy sending SIGTERM to the launcher as
+	// the sidecar's PID 1), cancel this context. Each launch goroutine forwards the
+	// signal to its runner child and waits for the runner to drain its in-flight task
+	// before exiting, so the runner is not torn down mid-execution.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
 	var wg sync.WaitGroup
 
 	for _, runnerType := range runnerTypes {
@@ -51,7 +61,7 @@ func main() {
 			logger := logs.NewLogger(logLevel, logPrefix)
 
 			cmd := commands.NewLaunchCommand(logger)
-			if err := cmd.Execute(launcherConfig, rt); err != nil {
+			if err := cmd.Execute(ctx, launcherConfig, rt); err != nil {
 				logger.Errorf("Failed to execute `launch` command: %v", err)
 			}
 		}(runnerType)

--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -42,10 +42,8 @@ func main() {
 
 	http.InitHealthCheckServer(launcherConfig.BaseConfig.HealthCheckServerPort)
 
-	// On SIGTERM/SIGINT (e.g. a k8s pod redeploy sending SIGTERM to the launcher as
-	// the sidecar's PID 1), cancel this context. Each launch goroutine forwards the
-	// signal to its runner child and waits for the runner to drain its in-flight task
-	// before exiting, so the runner is not torn down mid-execution.
+	// Cancelled on SIGTERM/SIGINT; each launch goroutine forwards the signal to its
+	// runner and waits for the runner to exit before returning.
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -71,7 +71,9 @@ On `SIGTERM`/`SIGINT` the launcher forwards the signal to the runner so it can f
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `N8N_RUNNERS_LAUNCHER_GRACEFUL_SHUTDOWN_TIMEOUT` | runner grace + 20 (= `50`) | Seconds the launcher waits for the runner to drain and exit before force-killing it. Derived from the runner's `N8N_RUNNERS_GRACEFUL_SHUTDOWN_TIMEOUT` plus a buffer, so raising the runner's grace raises this automatically; set it to override. |
+| `N8N_RUNNERS_LAUNCHER_GRACEFUL_SHUTDOWN_TIMEOUT` | runner grace + 2 x margin (= `50`) | Seconds the launcher waits for the runner to drain and exit before force-killing it. Derived as `N8N_RUNNERS_GRACEFUL_SHUTDOWN_TIMEOUT + 2 x N8N_RUNNERS_SHUTDOWN_FORCE_KILL_MARGIN`, so raising either raises this automatically; set it to override. |
+
+The runner force-exits itself at `grace + margin`; the launcher waits one further margin (`grace + 2 x margin`) so that self-exit happens first. Set `N8N_RUNNERS_SHUTDOWN_FORCE_KILL_MARGIN` (default `10`) on the runner's environment to tune the gap.
 
 Ensure your orchestrator's termination grace period (e.g. k8s `terminationGracePeriodSeconds`) is at least as large as this value, so the runner is not killed before it can drain.
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -65,6 +65,16 @@ It is required to pass `N8N_RUNNERS_AUTH_TOKEN` to the launcher and to the n8n i
 
 For any environment variable, you can append `_FILE` to specify a file path to read a value from. For example: `N8N_RUNNERS_AUTH_TOKEN_FILE=/path/to/auth-token.txt`
 
+### Graceful shutdown
+
+On `SIGTERM`/`SIGINT` the launcher forwards the signal to the runner so it can finish any in-flight task before exiting, then waits up to a grace period before force-killing it:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `N8N_RUNNERS_LAUNCHER_GRACEFUL_SHUTDOWN_TIMEOUT` | `50` | Seconds the launcher waits for the runner to drain and exit before force-killing it. |
+
+Ensure your orchestrator's termination grace period (e.g. k8s `terminationGracePeriodSeconds`) is at least as large as this value, so the runner is not killed before it can drain.
+
 The launcher can pass env vars to task runners in two ways, as specified in the [config file](#config-file):
 
 | Source | Description | Purpose |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -71,7 +71,7 @@ On `SIGTERM`/`SIGINT` the launcher forwards the signal to the runner so it can f
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `N8N_RUNNERS_LAUNCHER_GRACEFUL_SHUTDOWN_TIMEOUT` | `50` | Seconds the launcher waits for the runner to drain and exit before force-killing it. |
+| `N8N_RUNNERS_LAUNCHER_GRACEFUL_SHUTDOWN_TIMEOUT` | runner grace + 20 (= `50`) | Seconds the launcher waits for the runner to drain and exit before force-killing it. Derived from the runner's `N8N_RUNNERS_GRACEFUL_SHUTDOWN_TIMEOUT` plus a buffer, so raising the runner's grace raises this automatically; set it to override. |
 
 Ensure your orchestrator's termination grace period (e.g. k8s `terminationGracePeriodSeconds`) is at least as large as this value, so the runner is not killed before it can drain.
 

--- a/internal/commands/launch.go
+++ b/internal/commands/launch.go
@@ -18,16 +18,30 @@ import (
 	"time"
 )
 
-// launcherShutdownTimeout is how long the launcher waits for the runner to drain its
-// in-flight task after forwarding SIGTERM, before force-killing it. The default covers
-// the runner's default grace period plus its own force-exit backstop and connection
-// close; override with N8N_RUNNERS_LAUNCHER_GRACEFUL_SHUTDOWN_TIMEOUT (seconds).
+// runnerGraceBufferSeconds is how much longer than the runner's grace period the
+// launcher waits before force-killing it, leaving room for the runner's own force-exit
+// backstop and connection close so the launcher never SIGKILLs a still-draining runner.
+const runnerGraceBufferSeconds = 20
+
+// defaultRunnerGraceSeconds mirrors N8N_RUNNERS_GRACEFUL_SHUTDOWN_TIMEOUT's default in
+// packages/@n8n/task-runner (base-runner-config.ts) — keep in sync.
+const defaultRunnerGraceSeconds = 30
+
+// launcherShutdownTimeout is how long the launcher waits for the runner to drain after
+// forwarding SIGTERM, before force-killing it. It is derived from the runner's grace
+// period (N8N_RUNNERS_GRACEFUL_SHUTDOWN_TIMEOUT) plus a buffer so the two cannot drift;
+// N8N_RUNNERS_LAUNCHER_GRACEFUL_SHUTDOWN_TIMEOUT overrides it outright.
 func launcherShutdownTimeout() time.Duration {
-	const defaultSeconds = 50
 	if v, err := strconv.Atoi(os.Getenv("N8N_RUNNERS_LAUNCHER_GRACEFUL_SHUTDOWN_TIMEOUT")); err == nil && v > 0 {
 		return time.Duration(v) * time.Second
 	}
-	return defaultSeconds * time.Second
+
+	runnerGrace := defaultRunnerGraceSeconds
+	if v, err := strconv.Atoi(os.Getenv("N8N_RUNNERS_GRACEFUL_SHUTDOWN_TIMEOUT")); err == nil && v > 0 {
+		runnerGrace = v
+	}
+
+	return time.Duration(runnerGrace+runnerGraceBufferSeconds) * time.Second
 }
 
 type Command interface {

--- a/internal/commands/launch.go
+++ b/internal/commands/launch.go
@@ -18,30 +18,36 @@ import (
 	"time"
 )
 
-// runnerGraceBufferSeconds extends the runner grace to get the launcher's force-kill
-// delay. It must exceed the runner's own force-exit backstop (grace + 10s, in start.ts of
-// packages/@n8n/task-runner) so the runner exits first; change both together.
-const runnerGraceBufferSeconds = 20
+// Defaults mirror N8N_RUNNERS_GRACEFUL_SHUTDOWN_TIMEOUT and
+// N8N_RUNNERS_SHUTDOWN_FORCE_KILL_MARGIN in packages/@n8n/task-runner
+// (base-runner-config.ts) — keep in sync.
+const (
+	defaultRunnerGraceSeconds     = 30
+	defaultForceKillMarginSeconds = 10
+)
 
-// defaultRunnerGraceSeconds mirrors N8N_RUNNERS_GRACEFUL_SHUTDOWN_TIMEOUT's default in
-// packages/@n8n/task-runner (base-runner-config.ts) — keep in sync.
-const defaultRunnerGraceSeconds = 30
+// positiveEnvSeconds reads a positive integer from env, falling back to def.
+func positiveEnvSeconds(name string, def int) int {
+	if v, err := strconv.Atoi(os.Getenv(name)); err == nil && v > 0 {
+		return v
+	}
+	return def
+}
 
 // launcherShutdownTimeout is how long the launcher waits for the runner to drain after
-// forwarding SIGTERM, before force-killing it. It is derived from the runner's grace
-// period (N8N_RUNNERS_GRACEFUL_SHUTDOWN_TIMEOUT) plus a buffer so the two cannot drift;
-// N8N_RUNNERS_LAUNCHER_GRACEFUL_SHUTDOWN_TIMEOUT overrides it outright.
+// forwarding SIGTERM, before force-killing it. The runner force-exits itself at
+// grace + margin, so the launcher waits one further margin (grace + 2 × margin) to let
+// that self-exit happen first. Both values come from the runner's own env so the two
+// processes can't drift; N8N_RUNNERS_LAUNCHER_GRACEFUL_SHUTDOWN_TIMEOUT overrides it outright.
 func launcherShutdownTimeout() time.Duration {
 	if v, err := strconv.Atoi(os.Getenv("N8N_RUNNERS_LAUNCHER_GRACEFUL_SHUTDOWN_TIMEOUT")); err == nil && v > 0 {
 		return time.Duration(v) * time.Second
 	}
 
-	runnerGrace := defaultRunnerGraceSeconds
-	if v, err := strconv.Atoi(os.Getenv("N8N_RUNNERS_GRACEFUL_SHUTDOWN_TIMEOUT")); err == nil && v > 0 {
-		runnerGrace = v
-	}
+	grace := positiveEnvSeconds("N8N_RUNNERS_GRACEFUL_SHUTDOWN_TIMEOUT", defaultRunnerGraceSeconds)
+	margin := positiveEnvSeconds("N8N_RUNNERS_SHUTDOWN_FORCE_KILL_MARGIN", defaultForceKillMarginSeconds)
 
-	return time.Duration(runnerGrace+runnerGraceBufferSeconds) * time.Second
+	return time.Duration(grace+2*margin) * time.Second
 }
 
 type Command interface {

--- a/internal/commands/launch.go
+++ b/internal/commands/launch.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"sync"
+	"syscall"
 	"task-runner-launcher/internal/config"
 	"task-runner-launcher/internal/env"
 	"task-runner-launcher/internal/errs"
@@ -15,6 +17,18 @@ import (
 	"task-runner-launcher/internal/ws"
 	"time"
 )
+
+// launcherShutdownTimeout is how long the launcher waits for the runner to drain its
+// in-flight task after forwarding SIGTERM, before force-killing it. The default covers
+// the runner's default grace period plus its own force-exit backstop and connection
+// close; override with N8N_RUNNERS_LAUNCHER_GRACEFUL_SHUTDOWN_TIMEOUT (seconds).
+func launcherShutdownTimeout() time.Duration {
+	const defaultSeconds = 50
+	if v, err := strconv.Atoi(os.Getenv("N8N_RUNNERS_LAUNCHER_GRACEFUL_SHUTDOWN_TIMEOUT")); err == nil && v > 0 {
+		return time.Duration(v) * time.Second
+	}
+	return defaultSeconds * time.Second
+}
 
 type Command interface {
 	Execute() error
@@ -28,7 +42,19 @@ func NewLaunchCommand(logger *logs.Logger) *LaunchCommand {
 	return &LaunchCommand{logger: logger}
 }
 
-func (c *LaunchCommand) Execute(launcherConfig *config.LauncherConfig, runnerType string) error {
+// configureRunnerShutdown wires graceful shutdown onto the runner command: when its
+// context is cancelled (shutdown signal or health monitor), forward SIGTERM so the
+// runner can drain its in-flight task, bounded by waitDelay before the runtime
+// force-kills it with SIGKILL.
+func configureRunnerShutdown(cmd *exec.Cmd, waitDelay time.Duration, logger *logs.Logger) {
+	cmd.Cancel = func() error {
+		logger.Info("Forwarding shutdown signal to runner, waiting for it to drain...")
+		return cmd.Process.Signal(syscall.SIGTERM)
+	}
+	cmd.WaitDelay = waitDelay
+}
+
+func (c *LaunchCommand) Execute(ctx context.Context, launcherConfig *config.LauncherConfig, runnerType string) error {
 	c.logger.Info("Starting launcher goroutine...")
 
 	baseConfig := launcherConfig.BaseConfig
@@ -47,7 +73,17 @@ func (c *LaunchCommand) Execute(launcherConfig *config.LauncherConfig, runnerTyp
 	runnerEnv := env.PrepareRunnerEnv(baseConfig, runnerConfig, c.logger)
 	runnerServerURI := fmt.Sprintf("http://%s:%s", baseConfig.RunnerHealthCheckServerHost, runnerConfig.HealthCheckServerPort)
 
+	// Constant for the launcher's lifetime, so compute once.
+	runnerWaitDelay := launcherShutdownTimeout()
+
 	for {
+		// 0. stop relaunching once a shutdown signal has been received
+
+		if ctx.Err() != nil {
+			c.logger.Info("Received shutdown signal, launcher will stop")
+			return nil
+		}
+
 		// 3. check until task broker is ready
 
 		if err := http.CheckUntilBrokerReady(baseConfig.TaskBrokerURI, c.logger); err != nil {
@@ -71,8 +107,13 @@ func (c *LaunchCommand) Execute(launcherConfig *config.LauncherConfig, runnerTyp
 			GrantToken:          launcherGrantToken,
 		}
 
-		err = ws.Handshake(handshakeCfg, c.logger)
+		err = ws.Handshake(ctx, handshakeCfg, c.logger, runnerWaitDelay)
 		switch {
+		case errors.Is(err, errs.ErrShutdownRequested):
+			// Shutdown signalled and the grace period elapsed without a task to serve —
+			// exit cleanly without relaunching.
+			c.logger.Info("Received shutdown signal, launcher will stop")
+			return nil
 		case errors.Is(err, errs.ErrServerDown):
 			c.logger.Warn("Task broker is down, launcher will try to reconnect...")
 			time.Sleep(time.Second * 5)
@@ -98,29 +139,45 @@ func (c *LaunchCommand) Execute(launcherConfig *config.LauncherConfig, runnerTyp
 		c.logger.Debugf("Command: %s", runnerConfig.Command)
 		c.logger.Debugf("Args: %v", runnerConfig.Args)
 
-		ctx, cancelHealthMonitor := context.WithCancel(context.Background())
+		// Tie the runner to a context so cmd.Cancel can forward SIGTERM. If shutdown has
+		// already begun, the signal ctx is already cancelled — which would stop the process
+		// from even starting — so a runner launched now (to serve a task dispatched during
+		// the instance's drain) gets an independent, grace-bounded lifetime instead.
+		var runCtx context.Context
+		var cancelHealthMonitor context.CancelFunc
+		if ctx.Err() != nil {
+			runCtx, cancelHealthMonitor = context.WithTimeout(context.Background(), runnerWaitDelay)
+		} else {
+			runCtx, cancelHealthMonitor = context.WithCancel(ctx)
+		}
 		var wg sync.WaitGroup
 
-		cmd := exec.CommandContext(ctx, runnerConfig.Command, runnerConfig.Args...)
+		cmd := exec.CommandContext(runCtx, runnerConfig.Command, runnerConfig.Args...)
 		cmd.Env = runnerEnv
 		runnerPrefix := logs.GetRunnerPrefix(runnerType)
 		logLevel := logs.ParseLevel(launcherConfig.BaseConfig.LogLevel)
 		cmd.Stdout, cmd.Stderr = logs.GetRunnerWriters(logLevel, runnerPrefix)
+
+		configureRunnerShutdown(cmd, runnerWaitDelay, c.logger)
 
 		if err := cmd.Start(); err != nil {
 			cancelHealthMonitor()
 			return fmt.Errorf("failed to start runner process: %w", err)
 		}
 
-		go http.ManageRunnerHealth(ctx, cmd, runnerServerURI, &wg, c.logger)
+		go http.ManageRunnerHealth(runCtx, cmd, runnerServerURI, &wg, c.logger)
 
 		err = cmd.Wait()
-		if err != nil && err.Error() == "signal: killed" {
-			c.logger.Warn("Unresponsive runner process was terminated")
-		} else if err != nil {
-			c.logger.Errorf("Runner process exited with error: %v", err)
-		} else {
+		switch {
+		case err == nil:
 			c.logger.Info("Runner process exited on idle timeout")
+		case errors.Is(err, context.Canceled):
+			// Cancel forwarded SIGTERM and the runner drained and exited as a result.
+			c.logger.Info("Runner process drained and exited on shutdown")
+		case err.Error() == "signal: killed":
+			c.logger.Warn("Unresponsive runner process was terminated")
+		default:
+			c.logger.Errorf("Runner process exited with error: %v", err)
 		}
 		cancelHealthMonitor()
 

--- a/internal/commands/launch.go
+++ b/internal/commands/launch.go
@@ -18,11 +18,9 @@ import (
 	"time"
 )
 
-// runnerGraceBufferSeconds is added to the runner's grace period to get the launcher's
-// force-kill delay. It must stay larger than the runner's own force-exit backstop —
-// grace + 10s, in start.ts of packages/@n8n/task-runner — so the runner exits itself
-// before the launcher SIGKILLs a still-draining runner. The extra 10s is margin; if that
-// backstop changes, change this too.
+// runnerGraceBufferSeconds extends the runner grace to get the launcher's force-kill
+// delay. It must exceed the runner's own force-exit backstop (grace + 10s, in start.ts of
+// packages/@n8n/task-runner) so the runner exits first; change both together.
 const runnerGraceBufferSeconds = 20
 
 // defaultRunnerGraceSeconds mirrors N8N_RUNNERS_GRACEFUL_SHUTDOWN_TIMEOUT's default in
@@ -58,10 +56,8 @@ func NewLaunchCommand(logger *logs.Logger) *LaunchCommand {
 	return &LaunchCommand{logger: logger}
 }
 
-// configureRunnerShutdown wires graceful shutdown onto the runner command: when its
-// context is cancelled (shutdown signal or health monitor), forward SIGTERM so the
-// runner can drain its in-flight task, bounded by waitDelay before the runtime
-// force-kills it with SIGKILL.
+// configureRunnerShutdown forwards SIGTERM to the runner when its context is cancelled so
+// it can drain, then force-kills it after waitDelay.
 func configureRunnerShutdown(cmd *exec.Cmd, waitDelay time.Duration, logger *logs.Logger) {
 	cmd.Cancel = func() error {
 		logger.Info("Forwarding shutdown signal to runner, waiting for it to drain...")

--- a/internal/commands/launch.go
+++ b/internal/commands/launch.go
@@ -164,7 +164,10 @@ func (c *LaunchCommand) Execute(ctx context.Context, launcherConfig *config.Laun
 			return fmt.Errorf("failed to start runner process: %w", err)
 		}
 
-		go http.ManageRunnerHealth(runCtx, cmd, runnerServerURI, &wg, c.logger)
+		// Not `go`: ManageRunnerHealth returns immediately after spawning its own
+		// goroutines, and calling it synchronously ensures its wg.Add happens before
+		// the wg.Wait below (avoids a WaitGroup add/wait race).
+		http.ManageRunnerHealth(runCtx, cmd, runnerServerURI, &wg, c.logger)
 
 		err = cmd.Wait()
 		switch {

--- a/internal/commands/launch.go
+++ b/internal/commands/launch.go
@@ -139,10 +139,9 @@ func (c *LaunchCommand) Execute(ctx context.Context, launcherConfig *config.Laun
 		c.logger.Debugf("Command: %s", runnerConfig.Command)
 		c.logger.Debugf("Args: %v", runnerConfig.Args)
 
-		// Tie the runner to a context so cmd.Cancel can forward SIGTERM. If shutdown has
-		// already begun, the signal ctx is already cancelled — which would stop the process
-		// from even starting — so a runner launched now (to serve a task dispatched during
-		// the instance's drain) gets an independent, grace-bounded lifetime instead.
+		// Tie the runner to a context so cmd.Cancel can forward SIGTERM. When shutdown is
+		// already underway the signal ctx is cancelled, which would prevent the process
+		// from starting, so use an independent grace-bounded context instead.
 		var runCtx context.Context
 		var cancelHealthMonitor context.CancelFunc
 		if ctx.Err() != nil {

--- a/internal/commands/launch.go
+++ b/internal/commands/launch.go
@@ -77,8 +77,7 @@ func (c *LaunchCommand) Execute(ctx context.Context, launcherConfig *config.Laun
 	runnerWaitDelay := launcherShutdownTimeout()
 
 	for {
-		// 0. stop relaunching once a shutdown signal has been received
-
+		// Stop relaunching once a shutdown signal has been received.
 		if ctx.Err() != nil {
 			c.logger.Info("Received shutdown signal, launcher will stop")
 			return nil

--- a/internal/commands/launch.go
+++ b/internal/commands/launch.go
@@ -18,9 +18,11 @@ import (
 	"time"
 )
 
-// runnerGraceBufferSeconds is how much longer than the runner's grace period the
-// launcher waits before force-killing it, leaving room for the runner's own force-exit
-// backstop and connection close so the launcher never SIGKILLs a still-draining runner.
+// runnerGraceBufferSeconds is added to the runner's grace period to get the launcher's
+// force-kill delay. It must stay larger than the runner's own force-exit backstop —
+// grace + 10s, in start.ts of packages/@n8n/task-runner — so the runner exits itself
+// before the launcher SIGKILLs a still-draining runner. The extra 10s is margin; if that
+// backstop changes, change this too.
 const runnerGraceBufferSeconds = 20
 
 // defaultRunnerGraceSeconds mirrors N8N_RUNNERS_GRACEFUL_SHUTDOWN_TIMEOUT's default in

--- a/internal/commands/launch_test.go
+++ b/internal/commands/launch_test.go
@@ -190,17 +190,23 @@ func TestExecuteStopsOnCancelledContext(t *testing.T) {
 }
 
 func TestLauncherShutdownTimeout(t *testing.T) {
-	t.Run("defaults when unset", func(t *testing.T) {
-		assert.Equal(t, 50*time.Second, launcherShutdownTimeout())
+	t.Run("defaults to runner grace + buffer when unset", func(t *testing.T) {
+		assert.Equal(t, time.Duration(defaultRunnerGraceSeconds+runnerGraceBufferSeconds)*time.Second, launcherShutdownTimeout())
 	})
 
-	t.Run("honours a positive override", func(t *testing.T) {
+	t.Run("derives from the runner grace period so the two cannot drift", func(t *testing.T) {
+		t.Setenv("N8N_RUNNERS_GRACEFUL_SHUTDOWN_TIMEOUT", "60")
+		assert.Equal(t, time.Duration(60+runnerGraceBufferSeconds)*time.Second, launcherShutdownTimeout())
+	})
+
+	t.Run("honours an explicit launcher override", func(t *testing.T) {
 		t.Setenv("N8N_RUNNERS_LAUNCHER_GRACEFUL_SHUTDOWN_TIMEOUT", "90")
+		t.Setenv("N8N_RUNNERS_GRACEFUL_SHUTDOWN_TIMEOUT", "60")
 		assert.Equal(t, 90*time.Second, launcherShutdownTimeout())
 	})
 
-	t.Run("falls back to the default on invalid input", func(t *testing.T) {
+	t.Run("falls back to the runner-derived default on invalid input", func(t *testing.T) {
 		t.Setenv("N8N_RUNNERS_LAUNCHER_GRACEFUL_SHUTDOWN_TIMEOUT", "not-a-number")
-		assert.Equal(t, 50*time.Second, launcherShutdownTimeout())
+		assert.Equal(t, time.Duration(defaultRunnerGraceSeconds+runnerGraceBufferSeconds)*time.Second, launcherShutdownTimeout())
 	})
 }

--- a/internal/commands/launch_test.go
+++ b/internal/commands/launch_test.go
@@ -20,9 +20,10 @@ func TestConfigureRunnerShutdownForwardsSigterm(t *testing.T) {
 	dir := t.TempDir()
 	marker := filepath.Join(dir, "received-signal")
 	script := filepath.Join(dir, "runner.sh")
+	// Run via `sh script` (no exec bit needed), so 0600 is enough.
 	require.NoError(t, os.WriteFile(script,
 		[]byte("#!/bin/sh\ntrap 'echo TERM > "+marker+"; exit 0' TERM\nwhile true; do sleep 0.05; done\n"),
-		0o755))
+		0o600))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -38,6 +39,7 @@ func TestConfigureRunnerShutdownForwardsSigterm(t *testing.T) {
 	// The runner is sent SIGTERM (not the default SIGKILL), drains, and exits 0 — which
 	// surfaces from Wait as context.Canceled (the "drained on shutdown" arm).
 	assert.ErrorIs(t, err, context.Canceled)
+	// #nosec G304 -- marker is a test-controlled temp path
 	data, readErr := os.ReadFile(marker)
 	require.NoError(t, readErr, "runner should have caught SIGTERM and written the marker")
 	assert.Contains(t, string(data), "TERM")
@@ -48,7 +50,7 @@ func TestConfigureRunnerShutdownForceKillsUnresponsiveRunner(t *testing.T) {
 	dir := t.TempDir()
 	script := filepath.Join(dir, "runner.sh")
 	require.NoError(t, os.WriteFile(script,
-		[]byte("#!/bin/sh\ntrap '' TERM\nwhile true; do sleep 0.05; done\n"), 0o755))
+		[]byte("#!/bin/sh\ntrap '' TERM\nwhile true; do sleep 0.05; done\n"), 0o600))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/commands/launch_test.go
+++ b/internal/commands/launch_test.go
@@ -190,13 +190,20 @@ func TestExecuteStopsOnCancelledContext(t *testing.T) {
 }
 
 func TestLauncherShutdownTimeout(t *testing.T) {
-	t.Run("defaults to runner grace + buffer when unset", func(t *testing.T) {
-		assert.Equal(t, time.Duration(defaultRunnerGraceSeconds+runnerGraceBufferSeconds)*time.Second, launcherShutdownTimeout())
+	defaultTimeout := time.Duration(defaultRunnerGraceSeconds+2*defaultForceKillMarginSeconds) * time.Second
+
+	t.Run("defaults to runner grace + 2x margin when unset", func(t *testing.T) {
+		assert.Equal(t, defaultTimeout, launcherShutdownTimeout())
 	})
 
 	t.Run("derives from the runner grace period so the two cannot drift", func(t *testing.T) {
 		t.Setenv("N8N_RUNNERS_GRACEFUL_SHUTDOWN_TIMEOUT", "60")
-		assert.Equal(t, time.Duration(60+runnerGraceBufferSeconds)*time.Second, launcherShutdownTimeout())
+		assert.Equal(t, time.Duration(60+2*defaultForceKillMarginSeconds)*time.Second, launcherShutdownTimeout())
+	})
+
+	t.Run("derives from the force-kill margin so the two cannot drift", func(t *testing.T) {
+		t.Setenv("N8N_RUNNERS_SHUTDOWN_FORCE_KILL_MARGIN", "20")
+		assert.Equal(t, time.Duration(defaultRunnerGraceSeconds+2*20)*time.Second, launcherShutdownTimeout())
 	})
 
 	t.Run("honours an explicit launcher override", func(t *testing.T) {
@@ -207,6 +214,6 @@ func TestLauncherShutdownTimeout(t *testing.T) {
 
 	t.Run("falls back to the runner-derived default on invalid input", func(t *testing.T) {
 		t.Setenv("N8N_RUNNERS_LAUNCHER_GRACEFUL_SHUTDOWN_TIMEOUT", "not-a-number")
-		assert.Equal(t, time.Duration(defaultRunnerGraceSeconds+runnerGraceBufferSeconds)*time.Second, launcherShutdownTimeout())
+		assert.Equal(t, defaultTimeout, launcherShutdownTimeout())
 	})
 }

--- a/internal/commands/launch_test.go
+++ b/internal/commands/launch_test.go
@@ -1,0 +1,114 @@
+package commands
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"task-runner-launcher/internal/config"
+	"task-runner-launcher/internal/logs"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigureRunnerShutdownForwardsSigterm(t *testing.T) {
+	// Stub runner that traps SIGTERM, records it, and exits cleanly — the graceful
+	// drain we expect a real runner to perform.
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "received-signal")
+	script := filepath.Join(dir, "runner.sh")
+	require.NoError(t, os.WriteFile(script,
+		[]byte("#!/bin/sh\ntrap 'echo TERM > "+marker+"; exit 0' TERM\nwhile true; do sleep 0.05; done\n"),
+		0o755))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "/bin/sh", script)
+	configureRunnerShutdown(cmd, 5*time.Second, logs.NewLogger(logs.InfoLevel, ""))
+
+	require.NoError(t, cmd.Start())
+	time.Sleep(150 * time.Millisecond) // let the trap install
+	cancel()                           // simulate shutdown signal
+
+	err := cmd.Wait()
+
+	// The runner is sent SIGTERM (not the default SIGKILL), drains, and exits 0 — which
+	// surfaces from Wait as context.Canceled (the "drained on shutdown" arm).
+	assert.ErrorIs(t, err, context.Canceled)
+	data, readErr := os.ReadFile(marker)
+	require.NoError(t, readErr, "runner should have caught SIGTERM and written the marker")
+	assert.Contains(t, string(data), "TERM")
+}
+
+func TestConfigureRunnerShutdownForceKillsUnresponsiveRunner(t *testing.T) {
+	// Stub runner that ignores SIGTERM — WaitDelay must force-kill it (SIGKILL).
+	dir := t.TempDir()
+	script := filepath.Join(dir, "runner.sh")
+	require.NoError(t, os.WriteFile(script,
+		[]byte("#!/bin/sh\ntrap '' TERM\nwhile true; do sleep 0.05; done\n"), 0o755))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "/bin/sh", script)
+	configureRunnerShutdown(cmd, 200*time.Millisecond, logs.NewLogger(logs.InfoLevel, ""))
+
+	require.NoError(t, cmd.Start())
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	err := cmd.Wait()
+	assert.Error(t, err, "an unresponsive runner should be force-killed after WaitDelay")
+}
+
+func TestExecuteStopsOnCancelledContext(t *testing.T) {
+	// With an already-cancelled context (shutdown signalled), Execute must return
+	// cleanly without connecting to the broker or launching a runner.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cfg := &config.LauncherConfig{
+		BaseConfig: &config.BaseConfig{
+			TaskBrokerURI:               "http://127.0.0.1:1", // unreachable; must not be dialled
+			AuthToken:                   "test",
+			RunnerHealthCheckServerHost: "127.0.0.1",
+		},
+		RunnerConfigs: map[string]*config.RunnerConfig{
+			"javascript": {
+				RunnerType:            "javascript",
+				WorkDir:               t.TempDir(),
+				Command:               "node",
+				HealthCheckServerPort: "5681",
+			},
+		},
+	}
+
+	cmd := NewLaunchCommand(logs.NewLogger(logs.InfoLevel, ""))
+	done := make(chan error, 1)
+	go func() { done <- cmd.Execute(ctx, cfg, "javascript") }()
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err, "Execute should return nil when the context is already cancelled")
+	case <-time.After(2 * time.Second):
+		t.Fatal("Execute did not return promptly on a cancelled context")
+	}
+}
+
+func TestLauncherShutdownTimeout(t *testing.T) {
+	t.Run("defaults when unset", func(t *testing.T) {
+		assert.Equal(t, 50*time.Second, launcherShutdownTimeout())
+	})
+
+	t.Run("honours a positive override", func(t *testing.T) {
+		t.Setenv("N8N_RUNNERS_LAUNCHER_GRACEFUL_SHUTDOWN_TIMEOUT", "90")
+		assert.Equal(t, 90*time.Second, launcherShutdownTimeout())
+	})
+
+	t.Run("falls back to the default on invalid input", func(t *testing.T) {
+		t.Setenv("N8N_RUNNERS_LAUNCHER_GRACEFUL_SHUTDOWN_TIMEOUT", "not-a-number")
+		assert.Equal(t, 50*time.Second, launcherShutdownTimeout())
+	})
+}

--- a/internal/commands/launch_test.go
+++ b/internal/commands/launch_test.go
@@ -2,17 +2,107 @@ package commands
 
 import (
 	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"task-runner-launcher/internal/config"
 	"task-runner-launcher/internal/logs"
 	"testing"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// fakeBroker stands in for the task broker: it answers the readiness and grant-token
+// HTTP endpoints and completes the websocket handshake (accepting the launcher's offer).
+func fakeBroker(t *testing.T) *httptest.Server {
+	t.Helper()
+	upgrader := websocket.Upgrader{}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/healthz":
+			w.WriteHeader(http.StatusOK)
+		case r.URL.Path == "/runners/auth":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]string{"token": "grant-token"}})
+		case strings.HasPrefix(r.URL.Path, "/runners/_ws"):
+			conn, err := upgrader.Upgrade(w, r, nil)
+			if err != nil {
+				return
+			}
+			defer conn.Close()
+			var msg map[string]any
+			_ = conn.WriteJSON(map[string]any{"type": "broker:inforequest"})
+			_ = conn.ReadJSON(&msg) // runner:info
+			_ = conn.WriteJSON(map[string]any{"type": "broker:runnerregistered"})
+			_ = conn.ReadJSON(&msg) // runner:taskoffer
+			_ = conn.WriteJSON(map[string]any{"type": "broker:taskofferaccept", "taskId": "t1"})
+			_ = conn.ReadJSON(&msg) // runner:taskdeferred (launcher then closes the conn)
+		}
+	}))
+}
+
+func TestExecuteLaunchesRunnerThenStopsOnShutdown(t *testing.T) {
+	// os.Chdir is process-global; restore it so other tests aren't affected.
+	origWd, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(origWd) }()
+
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "runner-started")
+	script := filepath.Join(dir, "runner.sh")
+	require.NoError(t, os.WriteFile(script,
+		[]byte("#!/bin/sh\ntrap 'exit 0' TERM\necho up > "+marker+"\nwhile true; do sleep 0.05; done\n"),
+		0o600))
+
+	srv := fakeBroker(t)
+	defer srv.Close()
+	host, _, err := net.SplitHostPort(srv.Listener.Addr().String())
+	require.NoError(t, err)
+
+	cfg := &config.LauncherConfig{
+		BaseConfig: &config.BaseConfig{
+			TaskBrokerURI:               srv.URL,
+			AuthToken:                   "test",
+			RunnerHealthCheckServerHost: host,
+		},
+		RunnerConfigs: map[string]*config.RunnerConfig{
+			"javascript": {
+				RunnerType:            "javascript",
+				WorkDir:               dir,
+				Command:               "/bin/sh",
+				Args:                  []string{script},
+				HealthCheckServerPort: "5681",
+			},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cmd := NewLaunchCommand(logs.NewLogger(logs.InfoLevel, ""))
+	done := make(chan error, 1)
+	go func() { done <- cmd.Execute(ctx, cfg, "javascript") }()
+
+	// The launcher completes the handshake and launches the runner (which writes the marker).
+	require.Eventually(t, func() bool { _, statErr := os.Stat(marker); return statErr == nil },
+		8*time.Second, 50*time.Millisecond, "launcher should have launched the runner")
+
+	// Shutdown: the launcher forwards SIGTERM to the runner, it drains, and the loop stops.
+	cancel()
+	select {
+	case execErr := <-done:
+		assert.NoError(t, execErr, "Execute should stop cleanly on shutdown")
+	case <-time.After(10 * time.Second):
+		t.Fatal("Execute did not return after shutdown")
+	}
+}
 
 func TestConfigureRunnerShutdownForwardsSigterm(t *testing.T) {
 	// Stub runner that traps SIGTERM, records it, and exits cleanly — the graceful

--- a/internal/errs/errs.go
+++ b/internal/errs/errs.go
@@ -6,6 +6,10 @@ var (
 	// ErrServerDown is returned when the task broker server is down.
 	ErrServerDown = errors.New("task broker server is down")
 
+	// ErrShutdownRequested is returned by the handshake when a shutdown signal was
+	// received and the grace period elapsed without a task being dispatched.
+	ErrShutdownRequested = errors.New("shutdown requested")
+
 	// ErrWsMsgTooLarge is returned when the websocket message is too large for
 	// the launcher's websocket buffer.
 	ErrWsMsgTooLarge = errors.New("websocket message too large for buffer - please increase buffer size")

--- a/internal/http/manage_runner_health.go
+++ b/internal/http/manage_runner_health.go
@@ -132,7 +132,9 @@ func ManageRunnerHealth(
 				panic(fmt.Errorf("failed to terminate unhealthy runner process: %v", err))
 			}
 		case StatusMonitoringCancelled:
-			// On cancellation via context, CommandContext will terminate the process, so no action.
+			// On cancellation via context, the launch loop's cmd.Cancel forwards SIGTERM
+			// to the runner and cmd.WaitDelay bounds the wait before a force-kill, so no
+			// action is needed here.
 		}
 	}()
 }

--- a/internal/http/manage_runner_health.go
+++ b/internal/http/manage_runner_health.go
@@ -20,7 +20,11 @@ var (
 	healthCheckInterval = 10 * time.Second
 
 	// healthCheckMaxFailures is the max number of times a runner can be found
-	// unresponsive before the launcher terminates the runner.
+	// unresponsive before the launcher terminates the runner. The resulting unhealthy
+	// ceiling (initialDelay + healthCheckMaxFailures*healthCheckInterval ≈ 63s) should
+	// stay above the launcher's shutdown timeout, so a runner draining on shutdown is not
+	// force-killed as "unresponsive". (During a normal-mode shutdown the monitor's context
+	// is cancelled first, so this only matters for a runner launched mid-shutdown.)
 	healthCheckMaxFailures = 6
 
 	// initialDelay is the time (in seconds) to wait before sending the first

--- a/internal/http/manage_runner_health.go
+++ b/internal/http/manage_runner_health.go
@@ -19,12 +19,9 @@ var (
 	// sends a health check request to the runner.
 	healthCheckInterval = 10 * time.Second
 
-	// healthCheckMaxFailures is the max number of times a runner can be found
-	// unresponsive before the launcher terminates the runner. The resulting unhealthy
-	// ceiling (initialDelay + healthCheckMaxFailures*healthCheckInterval ≈ 63s) should
-	// stay above the launcher's shutdown timeout, so a runner draining on shutdown is not
-	// force-killed as "unresponsive". (During a normal-mode shutdown the monitor's context
-	// is cancelled first, so this only matters for a runner launched mid-shutdown.)
+	// healthCheckMaxFailures is the max unresponsive checks before the launcher kills the
+	// runner. The resulting ceiling (initialDelay + maxFailures*interval ≈ 63s) should stay
+	// above the launcher shutdown timeout, so a draining runner isn't killed as unresponsive.
 	healthCheckMaxFailures = 6
 
 	// initialDelay is the time (in seconds) to wait before sending the first

--- a/internal/http/manage_runner_health.go
+++ b/internal/http/manage_runner_health.go
@@ -19,9 +19,10 @@ var (
 	// sends a health check request to the runner.
 	healthCheckInterval = 10 * time.Second
 
-	// healthCheckMaxFailures is the max unresponsive checks before the launcher kills the
-	// runner. The resulting ceiling (initialDelay + maxFailures*interval ≈ 63s) should stay
-	// above the launcher shutdown timeout, so a draining runner isn't killed as unresponsive.
+	// healthCheckMaxFailures is the max consecutive unresponsive checks before the launcher
+	// kills the runner. This is a liveness watchdog for normal operation only: on shutdown
+	// the monitor's context is cancelled (StatusMonitoringCancelled), so it never kills a
+	// draining runner regardless of how the grace period is tuned.
 	healthCheckMaxFailures = 6
 
 	// initialDelay is the time (in seconds) to wait before sending the first

--- a/internal/ws/handshake.go
+++ b/internal/ws/handshake.go
@@ -206,10 +206,9 @@ func Handshake(ctx context.Context, cfg HandshakeConfig, logger *logs.Logger, gr
 		}
 	}()
 
-	// On a shutdown signal, don't leave immediately: keep the offer alive so a task
-	// dispatched while the n8n instance drains can still be picked up and a runner
-	// launched to serve it. Give up only on grace expiry, the broker closing the
-	// connection (via errReceived), or the offer being accepted.
+	// On a shutdown signal, keep the offer alive instead of returning: wait for the offer
+	// to be accepted, the broker to close the connection (via errReceived), or the grace
+	// period to elapse, whichever comes first.
 	ctxDone := ctx.Done()
 	var graceExpired <-chan time.Time
 

--- a/internal/ws/handshake.go
+++ b/internal/ws/handshake.go
@@ -1,12 +1,14 @@
 package ws
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
 	"net/url"
 	"task-runner-launcher/internal/errs"
 	"task-runner-launcher/internal/logs"
+	"time"
 
 	"github.com/gorilla/websocket"
 )
@@ -107,7 +109,7 @@ func isWsCloseError(err error) bool {
 // registers, sends a non-expiring task offer, and receives the accept for that
 // offer. Note that the handshake completes only once this task offer is accepted,
 // which may take time.
-func Handshake(cfg HandshakeConfig, logger *logs.Logger) error {
+func Handshake(ctx context.Context, cfg HandshakeConfig, logger *logs.Logger, gracePeriod time.Duration) error {
 	if err := validateConfig(cfg); err != nil {
 		return fmt.Errorf("received invalid handshake config: %w", err)
 	}
@@ -125,7 +127,9 @@ func Handshake(cfg HandshakeConfig, logger *logs.Logger) error {
 		return err
 	}
 
-	errReceived := make(chan error)
+	// Buffered so the reader goroutine never blocks sending its final error when
+	// nobody is receiving (e.g. after a ctx-cancelled return), avoiding a leak.
+	errReceived := make(chan error, 1)
 	handshakeComplete := make(chan struct{})
 
 	go func() {
@@ -202,12 +206,28 @@ func Handshake(cfg HandshakeConfig, logger *logs.Logger) error {
 		}
 	}()
 
-	select {
-	case err := <-errReceived:
-		wsConn.Close()
-		return err
-	case <-handshakeComplete:
-		logger.Debug("Runner's task offer was accepted")
-		return nil
+	// On a shutdown signal, don't leave immediately: keep the offer alive so a task
+	// dispatched while the n8n instance drains can still be picked up and a runner
+	// launched to serve it. Give up only on grace expiry, the broker closing the
+	// connection (via errReceived), or the offer being accepted.
+	ctxDone := ctx.Done()
+	var graceExpired <-chan time.Time
+
+	for {
+		select {
+		case err := <-errReceived:
+			wsConn.Close()
+			return err
+		case <-handshakeComplete:
+			logger.Debug("Runner's task offer was accepted")
+			return nil
+		case <-ctxDone:
+			logger.Info("Shutdown signalled; staying available until a task is dispatched, the broker drains, or the grace period ends")
+			ctxDone = nil // stop re-selecting on the (now-closed) ctx channel
+			graceExpired = time.After(gracePeriod)
+		case <-graceExpired:
+			wsConn.Close()
+			return errs.ErrShutdownRequested
+		}
 	}
 }

--- a/internal/ws/handshake_test.go
+++ b/internal/ws/handshake_test.go
@@ -1,6 +1,7 @@
 package ws
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -145,7 +146,7 @@ func TestHandshake(t *testing.T) {
 			}
 
 			logger := logs.NewLogger(logs.InfoLevel, "")
-			err := Handshake(tt.config, logger)
+			err := Handshake(context.Background(), tt.config, logger, 30*time.Second)
 
 			if tt.expectedError != "" {
 				assert.Error(t, err)
@@ -222,11 +223,11 @@ func TestHandshakeTimeout(t *testing.T) {
 	done := make(chan error)
 	go func() {
 		logger := logs.NewLogger(logs.InfoLevel, "")
-		done <- Handshake(HandshakeConfig{
+		done <- Handshake(context.Background(), HandshakeConfig{
 			TaskType:            "javascript",
 			TaskBrokerServerURI: "http://" + srv.Listener.Addr().String(),
 			GrantToken:          "test-token",
-		}, logger)
+		}, logger, 30*time.Second)
 	}()
 
 	select {
@@ -234,5 +235,59 @@ func TestHandshakeTimeout(t *testing.T) {
 		assert.Error(t, err, "Expected timeout error")
 	case <-time.After(200 * time.Millisecond):
 		t.Error("Test timed out")
+	}
+}
+
+func TestHandshakeStaysAvailableThenStopsOnGraceExpiry(t *testing.T) {
+	// Server completes registration but never accepts the offer, so the launcher parks
+	// waiting — the state an idle launcher sidecar is in when a pod redeploy hits.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err, "Failed to upgrade connection")
+		defer conn.Close()
+
+		require.NoError(t, conn.WriteJSON(message{Type: msgBrokerInfoRequest}))
+		var msg message
+		require.NoError(t, conn.ReadJSON(&msg), "Failed to read `runner:info`")
+		require.NoError(t, conn.WriteJSON(message{Type: msgBrokerRunnerRegistered}))
+
+		time.Sleep(2 * time.Second) // never send `broker:taskofferaccept`
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	const grace = 300 * time.Millisecond
+	done := make(chan error)
+	start := make(chan struct{})
+	go func() {
+		logger := logs.NewLogger(logs.InfoLevel, "")
+		close(start)
+		done <- Handshake(ctx, HandshakeConfig{
+			TaskType:            "javascript",
+			TaskBrokerServerURI: "http://" + srv.Listener.Addr().String(),
+			GrantToken:          "test-token",
+		}, logger, grace)
+	}()
+
+	<-start
+	// Simulate SIGTERM arriving while the launcher waits for its offer to be accepted.
+	// The launcher should NOT leave immediately — it stays available (so a task dispatched
+	// during the instance's drain can still be served) until the grace period elapses.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	// Must still be waiting right after cancellation (within the grace window).
+	select {
+	case <-done:
+		t.Fatal("Handshake returned immediately on cancellation; it should stay available during the grace period")
+	case <-time.After(grace / 2):
+	}
+
+	// Once the grace period elapses with no task, it stops cleanly.
+	select {
+	case err := <-done:
+		assert.ErrorIs(t, err, errs.ErrShutdownRequested, "Handshake should stop with ErrShutdownRequested after grace")
+	case <-time.After(2 * time.Second):
+		t.Error("Handshake did not return after the grace period elapsed")
 	}
 }


### PR DESCRIPTION

Related PR: https://github.com/n8n-io/task-runner-launcher/pull/103#issue-4674319587

## Summary

The launcher is the task-runner sidecar's PID 1. On a k8s pod redeploy, `SIGTERM` is sent
to every container at once — so the launcher and the n8n worker get it simultaneously.
Previously the launcher had **no signal handling**: the Go runtime's default terminated it
immediately, tearing down the runner child mid-task. An in-flight workflow's Code node then
failed with a task-runner disconnect — even though the worker was still gracefully draining
the execution.

This change makes the launcher shut down gracefully:

- **Trap `SIGTERM`/`SIGINT`** (`signal.NotifyContext`) and thread the context through the
  launch loop, which stops relaunching once shutdown begins.
- **A running runner**: forward `SIGTERM` to it (`cmd.Cancel`) so it can drain its in-flight
  task, then wait up to a grace period (`cmd.WaitDelay`) before the runtime force-kills it.
- **An idle launcher** (parked in the handshake, no runner yet): stay registered and keep
  its task offer alive so the still-draining worker can still get a runner for a Code node;
  give up only when the offer is accepted (launch the runner), the broker closes the
  connection, or the grace period elapses.

Grace period: `N8N_RUNNERS_LAUNCHER_GRACEFUL_SHUTDOWN_TIMEOUT` (default 50s — covers the
runner's own grace + force-exit backstop + connection close). Operators should set the
orchestrator's `terminationGracePeriodSeconds` ≥ this value.

This is the load-bearing half of the CAT-2549 fix for the external/k8s setup; it pairs with
the n8n runner-side change (keep serving during the broker's drain window). Reviewable on
its own — it fixes the reported incident (a Code task running when SIGTERM hits).

## How to test

External runner managed by this launcher, against an n8n worker in queue mode:
1. Run a workflow whose Code node is executing on the runner.
2. `SIGTERM` the worker pod (worker + launcher sidecar).
3. Expected: the launcher forwards `SIGTERM` to the runner, the runner drains its task, the
   execution completes successfully — instead of the runner being killed and the task
   failing.

Go suite: `go test ./...` (handshake stay-available + grace-expiry; `configureRunnerShutdown`
SIGTERM-forward + force-kill; loop-stop on cancellation; grace env parsing).

## Related
https://linear.app/n8n/issue/CAT-2549

## Files
- `cmd/launcher/main.go` — `signal.NotifyContext`, ctx → `Execute`.
- `internal/commands/launch.go` — loop-stop; `configureRunnerShutdown` (forward SIGTERM + WaitDelay); independent ctx for a runner launched during shutdown; `launcherShutdownTimeout`; exit classification.
- `internal/ws/handshake.go` — stay available on `ctx.Done` until offer-accept / close / grace; buffered `errReceived`.
- `internal/errs/errs.go` — `ErrShutdownRequested`.
- `internal/http/manage_runner_health.go` — comment fix.
- `docs/setup.md` — graceful-shutdown env doc.
- `internal/ws/handshake_test.go`, `internal/commands/launch_test.go` — tests.

## Suggested commits (review order)
1. `feat: Trap SIGTERM/SIGINT and stop relaunching on shutdown` — main.go, launch.go loop-stop
2. `feat: Forward SIGTERM to the runner and wait for graceful drain` — launch.go (configureRunnerShutdown, runCtx, classification, launcherShutdownTimeout)
3. `feat: Keep the launcher available during shutdown until the broker drains` — handshake.go, errs.go, launch.go ErrShutdownRequested handling
4. `test: Cover graceful-shutdown signal forwarding and handshake defer` — handshake_test.go, launch_test.go
5. `docs: Document the launcher graceful-shutdown timeout` — setup.md, manage_runner_health.go comment

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Graceful shutdown for the launcher: traps SIGTERM/SIGINT, forwards SIGTERM to the runner, and waits for a timeout derived from the runner grace + 2x margin (default 50s) before force-killing. Prevents Code node failures on k8s redeploys and lets workflows finish within CAT-2549’s grace window; ensure your orchestrator grace (e.g., k8s `terminationGracePeriodSeconds`) is ≥ the launcher wait.

- **New Features**
  - Trap SIGTERM/SIGINT in `main`, pass a cancelable context to `Execute`, and stop relaunching once shutdown starts.
  - For a running runner, forward SIGTERM via `cmd.Cancel` and bound wait via `cmd.WaitDelay = launcherShutdownTimeout()`; derived as `N8N_RUNNERS_GRACEFUL_SHUTDOWN_TIMEOUT + 2 x N8N_RUNNERS_SHUTDOWN_FORCE_KILL_MARGIN` (override with `N8N_RUNNERS_LAUNCHER_GRACEFUL_SHUTDOWN_TIMEOUT`).
  - When idle in handshake, stay available on shutdown; exit on offer accept, broker close, or grace expiry (`ErrShutdownRequested`). Docs clarify the cross-component timeout and that the health watchdog won’t kill a draining runner.

- **Bug Fixes**
  - Avoid a WaitGroup add/wait race by calling `ManageRunnerHealth` synchronously.

<sup>Written for commit 983ab88ad7cd9ac0c8971566f6917675698c41a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/task-runner-launcher/pull/103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

